### PR TITLE
Add callback for reliable messages

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -268,13 +268,7 @@ namespace Riptide
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
         /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
         /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
-        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null)
-        {
-            if (receivedCallback != null)
-                connection.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
-            else
-                connection.Send(message, shouldRelease);
-        }
+        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null) => connection.Send(message, shouldRelease, (id) => receivedCallback?.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
 
         /// <summary>Disconnects from the server.</summary>
         public void Disconnect()

--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -266,8 +266,15 @@ namespace Riptide
         /// <summary>Sends a message to the server.</summary>
         /// <param name="message">The message to send.</param>
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
-        /// <remarks><inheritdoc cref="Connection.Send(Message, bool)"/></remarks>
-        public void Send(Message message, bool shouldRelease = true) => connection.Send(message, shouldRelease);
+        /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
+        /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
+        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null)
+        {
+            if (receivedCallback != null)
+                connection.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
+            else
+                connection.Send(message, shouldRelease);
+        }
 
         /// <summary>Disconnects from the server.</summary>
         public void Disconnect()

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -289,13 +289,7 @@ namespace Riptide
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
         /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
         /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
-        public void Send(Message message, Connection toClient, bool shouldRelease = true, Action receivedCallback = null)
-        {
-            if (receivedCallback != null)
-                toClient.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since we already know the ID of the client to which the message is sent to
-            else
-                toClient.Send(message, shouldRelease);
-        }
+        public void Send(Message message, Connection toClient, bool shouldRelease = true, Action receivedCallback = null) => toClient.Send(message, shouldRelease, (id) => receivedCallback?.Invoke()); // Ignore the parameter since we already know the ID of the client to which the message is sent to
 
         /// <summary>Sends a message to all connected clients.</summary>
         /// <param name="message">The message to send.</param>

--- a/Unity/Packages/Core/Runtime/Client.cs
+++ b/Unity/Packages/Core/Runtime/Client.cs
@@ -268,13 +268,7 @@ namespace Riptide
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
         /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
         /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
-        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null)
-        {
-            if (receivedCallback != null)
-                connection.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
-            else
-                connection.Send(message, shouldRelease);
-        }
+        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null) => connection.Send(message, shouldRelease, (id) => receivedCallback?.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
 
         /// <summary>Disconnects from the server.</summary>
         public void Disconnect()

--- a/Unity/Packages/Core/Runtime/Client.cs
+++ b/Unity/Packages/Core/Runtime/Client.cs
@@ -266,8 +266,15 @@ namespace Riptide
         /// <summary>Sends a message to the server.</summary>
         /// <param name="message">The message to send.</param>
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
-        /// <remarks><inheritdoc cref="Connection.Send(Message, bool)"/></remarks>
-        public void Send(Message message, bool shouldRelease = true) => connection.Send(message, shouldRelease);
+        /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
+        /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
+        public void Send(Message message, bool shouldRelease = true, Action receivedCallback = null)
+        {
+            if (receivedCallback != null)
+                connection.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since it will return the ID of the connection to the server
+            else
+                connection.Send(message, shouldRelease);
+        }
 
         /// <summary>Disconnects from the server.</summary>
         public void Disconnect()

--- a/Unity/Packages/Core/Runtime/Server.cs
+++ b/Unity/Packages/Core/Runtime/Server.cs
@@ -289,13 +289,7 @@ namespace Riptide
         /// <param name="shouldRelease">Whether or not to return the message to the pool after it is sent.</param>
         /// <param name="receivedCallback">A callback for when a <b>RELIABLY</b> sent message arrives.</param>
         /// <remarks><inheritdoc cref="Connection.Send(Message, bool, Action{ushort})"/></remarks>
-        public void Send(Message message, Connection toClient, bool shouldRelease = true, Action receivedCallback = null)
-        {
-            if (receivedCallback != null)
-                toClient.Send(message, shouldRelease, (id) => receivedCallback.Invoke()); // Ignore the parameter since we already know the ID of the client to which the message is sent to
-            else
-                toClient.Send(message, shouldRelease);
-        }
+        public void Send(Message message, Connection toClient, bool shouldRelease = true, Action receivedCallback = null) => toClient.Send(message, shouldRelease, (id) => receivedCallback?.Invoke()); // Ignore the parameter since we already know the ID of the client to which the message is sent to
 
         /// <summary>Sends a message to all connected clients.</summary>
         /// <param name="message">The message to send.</param>


### PR DESCRIPTION
Added a callback for when reliable messages arrive. This would allow the developer to execute some code after a message is successfully received. This is similar to what it is proposed in issue #42 .

### How to use

Pass a callback to the `Send` methods of clients and servers. In the case of the server's `SendToAll`, the callback needs to have a `ushort` parameter for the ID of the connection to which the message was sent to. This is useful in the case that after a message arrived you want to send another message to the same client.

#### Please let me know if this is okay or if I should change something.