### PR TITLE
Seal classes

### DIFF
--- a/RiptideNetworking/RiptideNetworking/EventArgs.cs
+++ b/RiptideNetworking/RiptideNetworking/EventArgs.cs
@@ -8,7 +8,7 @@ using System;
 namespace Riptide
 {
     /// <summary>Contains event data for when a client connects to the server.</summary>
-    public class ServerConnectedEventArgs : EventArgs
+    public sealed class ServerConnectedEventArgs : EventArgs
     {
         /// <summary>The newly connected client.</summary>
         public readonly Connection Client;
@@ -22,7 +22,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when a client disconnects from the server.</summary>
-    public class ServerDisconnectedEventArgs : EventArgs
+    public sealed class ServerDisconnectedEventArgs : EventArgs
     {
         /// <summary>The client that disconnected.</summary>
         public readonly Connection Client;
@@ -40,7 +40,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when a message is received.</summary>
-    public class MessageReceivedEventArgs : EventArgs
+    public sealed class MessageReceivedEventArgs : EventArgs
     {
         /// <summary>The connection from which the message was received.</summary>
         public readonly Connection FromConnection;
@@ -62,7 +62,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when a connection attempt to a server fails.</summary>
-    public class ConnectionFailedEventArgs : EventArgs
+    public sealed class ConnectionFailedEventArgs : EventArgs
     {
         /// <summary>Additional data related to the failed connection attempt (if any).</summary>
         public readonly Message Message;
@@ -73,7 +73,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when the client disconnects from a server.</summary>
-    public class DisconnectedEventArgs : EventArgs
+    public sealed class DisconnectedEventArgs : EventArgs
     {
         /// <summary>The reason for the disconnection.</summary>
         public readonly DisconnectReason Reason;
@@ -91,7 +91,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when a non-local client connects to the server.</summary>
-    public class ClientConnectedEventArgs : EventArgs
+    public sealed class ClientConnectedEventArgs : EventArgs
     {
         /// <summary>The numeric ID of the client that connected.</summary>
         public readonly ushort Id;
@@ -102,7 +102,7 @@ namespace Riptide
     }
 
     /// <summary>Contains event data for when a non-local client disconnects from the server.</summary>
-    public class ClientDisconnectedEventArgs : EventArgs
+    public sealed class ClientDisconnectedEventArgs : EventArgs
     {
         /// <summary>The numeric ID of the client that disconnected.</summary>
         public readonly ushort Id;

--- a/RiptideNetworking/RiptideNetworking/Exceptions.cs
+++ b/RiptideNetworking/RiptideNetworking/Exceptions.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 namespace Riptide
 {
     /// <summary>The exception that is thrown when a <see cref="Message"/> does not contain enough unread bytes to add a certain value.</summary>
-    public class InsufficientCapacityException : Exception
+    public sealed class InsufficientCapacityException : Exception
     {
         /// <summary>The message with insufficient remaining capacity.</summary>
         public readonly Message RiptideMessage;

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -21,7 +21,7 @@ namespace Riptide
     }
 
     /// <summary>Provides functionality for converting data to bytes and vice versa.</summary>
-    public class Message
+    public sealed class Message
     {
         /// <summary>The maximum number of bytes required for a message's header.</summary>
         /// <remarks>1 byte for the actual header, 2 bytes for the sequence ID (only for reliable messages), 2 bytes for the message ID. Messages sent unreliably will use 2 bytes less than this value for the header.</remarks>

--- a/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
+++ b/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace Riptide
 {
     /// <summary>Provides functionality for enabling/disabling automatic message relaying by message type.</summary>
-    public class MessageRelayFilter
+    public sealed class MessageRelayFilter
     {
         /// <summary>The number of bits an int consists of.</summary>
         private const int BitsPerInt = sizeof(int) * 8;

--- a/RiptideNetworking/RiptideNetworking/PendingMessage.cs
+++ b/RiptideNetworking/RiptideNetworking/PendingMessage.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 namespace Riptide
 {
     /// <summary>Represents a currently pending reliably sent message whose delivery has not been acknowledged yet.</summary>
-    internal class PendingMessage
+    internal sealed class PendingMessage
     {
         /// <summary>The time of the latest send attempt.</summary>
         internal long LastSendTime { get; private set; }

--- a/RiptideNetworking/RiptideNetworking/Utils/ActionQueue.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/ActionQueue.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace Riptide.Utils
 {
     /// <summary>Provides functionality for queueing methods for later execution from a chosen thread.</summary>
-    public class ActionQueue
+    public sealed class ActionQueue
     {
         /// <summary>The name to use when logging messages via <see cref="RiptideLogger"/>.</summary>
         public readonly string LogName;

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 namespace Riptide.Utils
 {
     /// <summary>Provides functionality for converting bytes to various value types and vice versa.</summary>
-    public class Converter
+    public sealed class Converter
     {
         #region Short/UShort
         /// <summary>Converts a given <see cref="short"/> to bytes and writes them into the given array.</summary>

--- a/RiptideNetworking/RiptideNetworking/Utils/DelayedEvents.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/DelayedEvents.cs
@@ -13,7 +13,7 @@ namespace Riptide.Utils
     }
 
     /// <summary>Resends a <see cref="PendingMessage"/> when invoked.</summary>
-    internal class PendingMessageResendEvent : DelayedEvent
+    internal sealed class PendingMessageResendEvent : DelayedEvent
     {
         /// <summary>The message to resend.</summary>
         private readonly PendingMessage message;

--- a/RiptideNetworking/RiptideNetworking/Utils/Helper.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Helper.cs
@@ -8,7 +8,7 @@ using System;
 namespace Riptide.Utils
 {
     /// <summary>Contains miscellaneous helper methods.</summary>
-    internal class Helper
+    internal sealed class Helper
     {
         /// <summary>Determines whether <paramref name="singular"/> or <paramref name="plural"/> form should be used based on the <paramref name="amount"/>.</summary>
         /// <param name="amount">The amount that <paramref name="singular"/> and <paramref name="plural"/> refer to.</param>

--- a/RiptideNetworking/RiptideNetworking/Utils/PriorityQueue.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/PriorityQueue.cs
@@ -12,7 +12,7 @@ namespace Riptide.Utils
     /// <summary>Represents a collection of items that have a value and a priority. On dequeue, the item with the lowest priority value is removed.</summary>
     /// <typeparam name="TElement">Specifies the type of elements in the queue.</typeparam>
     /// <typeparam name="TPriority">Specifies the type of priority associated with enqueued elements.</typeparam>
-    internal class PriorityQueue<TElement, TPriority> where TPriority : IComparable<TPriority>
+    internal sealed class PriorityQueue<TElement, TPriority> where TPriority : IComparable<TPriority>
     {
         /// <summary>Gets the number of elements contained in the <see cref="PriorityQueue{TElement, TPriority}"/>.</summary>
         public int Count => entries.Count;

--- a/RiptideNetworking/RiptideNetworking/Utils/RiptideLogger.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/RiptideLogger.cs
@@ -22,7 +22,7 @@ namespace Riptide.Utils
     }
 
     /// <summary>Provides functionality for logging messages.</summary>
-    public class RiptideLogger
+    public sealed class RiptideLogger
     {
         /// <summary>Whether or not <see cref="LogType.Debug"/> messages will be logged.</summary>
         public static bool IsDebugLoggingEnabled => logMethods.ContainsKey(LogType.Debug);


### PR DESCRIPTION
Adding the `sealed` keyword to classes, which are not intended to be inherited, increases performance significantly. If they need to be extended later, removing the keyword shouldn’t be too difficult. 
Examples: [blog post](https://www.meziantou.net/performance-benefits-of-sealed-class.htm) or [video](https://www.youtube.com/watch?v=d76WWAD99Yo)

I wasn’t sure why the [Client](https://github.com/RiptideNetworking/Riptide/blob/main/RiptideNetworking/RiptideNetworking/Client.cs) and the [Server](https://github.com/RiptideNetworking/Riptide/blob/main/RiptideNetworking/RiptideNetworking/Server.cs) provide virtual methods, so I left them as they were.
