### PR TITLE
.NET Framework 3.5 support

### DIFF
--- a/RiptideNetworking/RiptideNetworking/RiptideNetworking.csproj
+++ b/RiptideNetworking/RiptideNetworking/RiptideNetworking.csproj
@@ -21,6 +21,7 @@
     <PackageReleaseNotes>[Release Notes](https://riptide.tomweiland.net/manual/updates/release-notes/v2.0.0.html)
 [Update Guide](https://riptide.tomweiland.net/manual/updates/guides/updating-to-v2.html)</PackageReleaseNotes>
     <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/RiptideNetworking/RiptideNetworking/RiptideNetworking.csproj
+++ b/RiptideNetworking/RiptideNetworking/RiptideNetworking.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net35</TargetFramework>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <RootNamespace>Riptide</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -21,18 +20,19 @@
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageReleaseNotes>[Release Notes](https://riptide.tomweiland.net/manual/updates/release-notes/v2.0.0.html)
 [Update Guide](https://riptide.tomweiland.net/manual/updates/guides/updating-to-v2.html)</PackageReleaseNotes>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE</DefineConstants>
-    <DocumentationFile>bin\Debug\netstandard2.0\RiptideNetworking.xml</DocumentationFile>
-    <OutputPath>bin\Debug\netstandard2.0\</OutputPath>
+    <DocumentationFile>bin\Debug\net35\RiptideNetworking.xml</DocumentationFile>
+    <OutputPath>bin\Debug\net35\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>bin\Release\netstandard2.0\</OutputPath>
-    <DocumentationFile>bin\Release\netstandard2.0\RiptideNetworking.xml</DocumentationFile>
+    <OutputPath>bin\Release\net35\</OutputPath>
+    <DocumentationFile>bin\Release\net35\RiptideNetworking.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RiptideNetworking/RiptideNetworking/Transports/EventArgs.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/EventArgs.cs
@@ -3,10 +3,12 @@
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/tom-weiland/RiptideNetworking/blob/main/LICENSE.md
 
+using System;
+
 namespace Riptide.Transports
 {
     /// <summary>Contains event data for when a server's transport successfully establishes a connection to a client.</summary>
-    public class ConnectedEventArgs
+    public class ConnectedEventArgs : EventArgs
     {
         /// <summary>The newly established connection.</summary>
         public readonly Connection Connection;
@@ -20,7 +22,7 @@ namespace Riptide.Transports
     }
 
     /// <summary>Contains event data for when a server's or client's transport receives data.</summary>
-    public class DataReceivedEventArgs
+    public class DataReceivedEventArgs : EventArgs
     {
         /// <summary>An array containing the received data.</summary>
         public readonly byte[] DataBuffer;
@@ -42,7 +44,7 @@ namespace Riptide.Transports
     }
 
     /// <summary>Contains event data for when a server's or client's transport initiates or detects a disconnection.</summary>
-    public class DisconnectedEventArgs
+    public class DisconnectedEventArgs : EventArgs
     {
         /// <summary>The closed connection.</summary>
         public readonly Connection Connection;

--- a/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpClient.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpClient.cs
@@ -35,11 +35,14 @@ namespace Riptide.Transports.Tcp
             }
 
             IPEndPoint remoteEndPoint = new IPEndPoint(ip, port);
-            socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+
+
+            socket = new Socket(AddressFamily.Unspecified, SocketType.Stream, ProtocolType.Tcp)
             {
                 SendBufferSize = socketBufferSize,
                 ReceiveBufferSize = socketBufferSize,
             };
+
             
             try
             {
@@ -70,7 +73,7 @@ namespace Riptide.Transports.Tcp
             if (ipAndPort.Length > 2)
             {
                 // There was more than one ':' in the host address, might be IPv6
-                ipString = string.Join(":", ipAndPort.Take(ipAndPort.Length - 1));
+                ipString = string.Join(":", ipAndPort.Take(ipAndPort.Length - 1).ToArray());
                 portString = ipAndPort[ipAndPort.Length - 1];
             }
             else if (ipAndPort.Length == 2)

--- a/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpClient.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpClient.cs
@@ -34,7 +34,7 @@ namespace Riptide.Transports.Tcp
                 return false;
             }
 
-            IPEndPoint remoteEndPoint = new IPEndPoint(ip, port);
+            IPEndPoint remoteEndPoint = new IPEndPoint(address: ip, port);
 
 
             socket = new Socket(AddressFamily.Unspecified, SocketType.Stream, ProtocolType.Tcp)

--- a/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
@@ -50,7 +50,7 @@ namespace Riptide.Transports.Tcp
                 StopListening();
 
             IPEndPoint localEndPoint = new IPEndPoint(IPAddress.IPv6Any, port);
-            socket = new Socket(SocketType.Stream, ProtocolType.Tcp)
+            socket = new Socket(AddressFamily.Unspecified, SocketType.Stream, ProtocolType.Tcp)
             {
                 SendBufferSize = socketBufferSize,
                 ReceiveBufferSize = socketBufferSize,

--- a/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
@@ -49,7 +49,7 @@ namespace Riptide.Transports.Tcp
             if (isRunning)
                 StopListening();
 
-            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.IPv6Any, port);
+            IPEndPoint localEndPoint = new IPEndPoint(address: IPAddress.IPv6Any, port);
             socket = new Socket(AddressFamily.Unspecified, SocketType.Stream, ProtocolType.Tcp)
             {
                 SendBufferSize = socketBufferSize,

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
@@ -25,7 +25,11 @@ namespace Riptide.Transports.Udp
         private UdpConnection udpConnection;
 
         /// <inheritdoc/>
+#if NET35
         public UdpClient(SocketMode mode = SocketMode.IPv4Only, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+#else
+        public UdpClient(SocketMode mode = SocketMode.Both, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+#endif
 
         /// <inheritdoc/>
         /// <remarks>Expects the host address to consist of an IP and port, separated by a colon. For example: <c>127.0.0.1:7777</c>.</remarks>

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
@@ -25,7 +25,7 @@ namespace Riptide.Transports.Udp
         private UdpConnection udpConnection;
 
         /// <inheritdoc/>
-        public UdpClient(SocketMode mode = SocketMode.Both, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+        public UdpClient(SocketMode mode = SocketMode.IPv4Only, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
 
         /// <inheritdoc/>
         /// <remarks>Expects the host address to consist of an IP and port, separated by a colon. For example: <c>127.0.0.1:7777</c>.</remarks>
@@ -52,7 +52,7 @@ namespace Riptide.Transports.Udp
 
             OpenSocket();
 
-            connection = udpConnection = new UdpConnection(new IPEndPoint(mode == SocketMode.IPv4Only ? ip : ip.MapToIPv6(), port), this);
+            connection = udpConnection = new UdpConnection(new IPEndPoint(address: mode == SocketMode.IPv4Only ? ip : ip.MapToIPv6(), port), this);
             OnConnected(); // UDP is connectionless, so from the transport POV everything is immediately ready to send/receive data
             return true;
         }

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpClient.cs
@@ -3,6 +3,7 @@
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/tom-weiland/RiptideNetworking/blob/main/LICENSE.md
 
+using Riptide.Utils;
 using System;
 using System.Linq;
 using System.Net;
@@ -69,7 +70,7 @@ namespace Riptide.Transports.Udp
             if (ipAndPort.Length > 2)
             {
                 // There was more than one ':' in the host address, might be IPv6
-                ipString = string.Join(":", ipAndPort.Take(ipAndPort.Length - 1));
+                ipString = string.Join(":", ipAndPort.Take(ipAndPort.Length - 1).ToArray());
                 portString = ipAndPort[ipAndPort.Length - 1];
             }
             else if (ipAndPort.Length == 2)

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
@@ -75,9 +75,15 @@ namespace Riptide.Transports.Udp
             if (mode == SocketMode.IPv4Only)
                 socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             else if (mode == SocketMode.IPv6Only)
+#if NET35
+                //DualMode doesn't actually seem to do anything important unless you use UNIX sockets (source .NET 6 source code: https://source.dot.net/#System.Net.Sockets/System/Net/Sockets/UDPClient.cs,207)
+                socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+#else
                 socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp) { DualMode = false };
+#endif
+                
             else
-                socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
+                socket = new Socket(AddressFamily.Unspecified, SocketType.Dgram, ProtocolType.Udp);
 
             IPAddress any = socket.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any;
             socket.SendBufferSize = socketBufferSize;

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
@@ -77,7 +77,7 @@ namespace Riptide.Transports.Udp
             else if (mode == SocketMode.IPv6Only)
 #if NET35
                 //DualMode doesn't actually seem to do anything important unless you use UNIX sockets (source .NET 6 source code: https://source.dot.net/#System.Net.Sockets/System/Net/Sockets/UDPClient.cs,207)
-                socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
 #else
                 socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp) { DualMode = false };
 #endif

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
@@ -91,8 +91,8 @@ namespace Riptide.Transports.Udp
             IPAddress any = socket.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any;
             socket.SendBufferSize = socketBufferSize;
             socket.ReceiveBufferSize = socketBufferSize;
-            socket.Bind(new IPEndPoint(any, port));
-            remoteEndPoint = new IPEndPoint(any, 0);
+            socket.Bind(new IPEndPoint(address: any, port));
+            remoteEndPoint = new IPEndPoint(address: any, 0);
 
             isRunning = true;
         }

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpPeer.cs
@@ -72,18 +72,21 @@ namespace Riptide.Transports.Udp
             if (isRunning)
                 CloseSocket();
 
+            
+            
+#if NET35
+            //0 clue why, but .NET Framework 3.5 doesn't support IPv6?
+            //TODO: What the actual fuck?
+            socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+#else
             if (mode == SocketMode.IPv4Only)
                 socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             else if (mode == SocketMode.IPv6Only)
-#if NET35
-                //DualMode doesn't actually seem to do anything important unless you use UNIX sockets (source .NET 6 source code: https://source.dot.net/#System.Net.Sockets/System/Net/Sockets/UDPClient.cs,207)
-                socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
-#else
                 socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp) { DualMode = false };
-#endif
-                
             else
                 socket = new Socket(AddressFamily.Unspecified, SocketType.Dgram, ProtocolType.Udp);
+#endif
+            
 
             IPAddress any = socket.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any;
             socket.SendBufferSize = socketBufferSize;

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
@@ -24,7 +24,7 @@ namespace Riptide.Transports.Udp
         private Dictionary<IPEndPoint, Connection> connections;
 
         /// <inheritdoc/>
-        public UdpServer(SocketMode mode = SocketMode.Both, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+        public UdpServer(SocketMode mode = SocketMode.IPv4Only, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
 
         /// <inheritdoc/>
         public void Start(ushort port)

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
@@ -32,6 +32,7 @@ namespace Riptide.Transports.Udp
             Port = port;
             connections = new Dictionary<IPEndPoint, Connection>();
 
+
             OpenSocket(port);
         }
 

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
@@ -24,7 +24,11 @@ namespace Riptide.Transports.Udp
         private Dictionary<IPEndPoint, Connection> connections;
 
         /// <inheritdoc/>
+#if NET35
         public UdpServer(SocketMode mode = SocketMode.IPv4Only, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+#else
+        public UdpServer(SocketMode mode = SocketMode.Both, int socketBufferSize = DefaultSocketBufferSize) : base(mode, socketBufferSize) { }
+#endif
 
         /// <inheritdoc/>
         public void Start(ushort port)

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -17,7 +17,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="short"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromShort(short value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -32,7 +34,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="ushort"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromUShort(ushort value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -48,7 +52,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="short"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static short ToShort(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -61,7 +67,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="ushort"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static ushort ToUShort(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -77,7 +85,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="int"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromInt(int value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -96,7 +106,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="uint"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromUInt(uint value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -116,7 +128,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="int"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int ToInt(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -129,7 +143,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="uint"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static uint ToUInt(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -145,7 +161,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="long"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromLong(long value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -172,7 +190,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="ulong"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromULong(ulong value, byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -200,7 +220,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="long"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static long ToLong(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -213,7 +235,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="ulong"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static ulong ToULong(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -228,7 +252,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="float"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromFloat(float value, byte[] array, int startIndex)
         {
             FloatConverter converter = new FloatConverter { FloatValue = value };
@@ -249,7 +275,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="float"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static float ToFloat(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN
@@ -265,7 +293,9 @@ namespace Riptide.Utils
         /// <param name="value">The <see cref="double"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static void FromDouble(double value, byte[] array, int startIndex)
         {
             DoubleConverter converter = new DoubleConverter { DoubleValue = value };
@@ -294,7 +324,9 @@ namespace Riptide.Utils
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="double"/>.</returns>
+#if !NET35
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static double ToDouble(byte[] array, int startIndex)
         {
 #if BIG_ENDIAN

--- a/RiptideNetworking/RiptideNetworking/Utils/Extensions.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Extensions.cs
@@ -14,7 +14,11 @@ namespace Riptide.Utils
         /// <returns>A string containing the IP address and port number of the endpoint.</returns>
         public static string ToStringBasedOnIPFormat(this IPEndPoint endPoint)
         {
+#if NET35
+            if (endPoint.Address.IsIPv4MappedToIPv6())
+#else
             if (endPoint.Address.IsIPv4MappedToIPv6)
+#endif
                 return $"{endPoint.Address.MapToIPv4()}:{endPoint.Port}";
             
             return endPoint.ToString();

--- a/RiptideNetworking/RiptideNetworking/Utils/Framework35Compatibility.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Framework35Compatibility.cs
@@ -1,0 +1,104 @@
+// This file is provided under The MIT License as part of RiptideNetworking.
+// Copyright (c) Tom Weiland
+// For additional information please see the included LICENSE.md file or view it on GitHub:
+// https://github.com/tom-weiland/RiptideNetworking/blob/main/LICENSE.md
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Riptide.Utils
+{
+    /// <summary>
+    /// Class for compatibility with .NET Framework 3.5
+    /// </summary>
+    public static class Framework35Compatibility
+    {
+        /// <summary>
+        /// Taken from https://source.dot.net/#System.Net.Primitives/src/libraries/Common/src/System/Net/IPAddressParserStatics.cs
+        /// </summary>
+        internal static class IPAddressParserStatics
+        {
+            public const int IPv4AddressBytes = 4;
+            public const int IPv6AddressBytes = 16;
+            public const int IPv6AddressShorts = IPv6AddressBytes / 2;
+        }
+        
+#if NET35
+        /// <inheritdoc cref="Attribute.GetCustomAttribute(System.Reflection.MemberInfo, System.Type)"/>
+        public static T GetCustomAttribute<T>(this MethodInfo self, bool inherit = true) where T : Attribute => (T)self.GetCustomAttributes(typeof(T), inherit)[0];
+
+        /// <inheritdoc cref="Delegate.Method"/>
+        public static MethodInfo GetMethodInfo(this Delegate self) => self.Method;
+
+        /// <inheritdoc cref="Stopwatch.Restart()"/>
+        public static void Restart(this Stopwatch self)
+        {
+            self.Stop();
+            self.Reset();
+            self.Start();
+        }
+
+        /// <summary>
+        /// Taken and adapted from https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/IPAddress.cs#L721
+        /// </summary>
+        /// <inheritdoc cref="IPAddress.MapToIPv6()"/>
+        public static IPAddress MapToIPv6(this IPAddress self)
+        {
+            if (self.AddressFamily == AddressFamily.InterNetworkV6)
+                return self;
+
+            //TODO: The byte order here might be an issue!
+            byte[] labels = new byte[IPAddressParserStatics.IPv6AddressBytes];
+            labels[10] = 0xFF; labels[11] = 0xFF;
+
+            //Am aware self.Address is depreciated, there is no other option
+#pragma warning disable CS0618
+            labels[12] = (byte)((self.Address & 0x0000FF00) >> 8);
+            labels[13] = (byte)(self.Address & 0x000000FF);
+            labels[14] = (byte)((self.Address & 0xFF000000) >> 24);
+            labels[15] = (byte)((self.Address & 0x00FF0000) >> 16);
+#pragma warning restore CS0618
+
+            return new IPAddress(labels, 0);
+        }
+
+        /// <summary>
+        /// Taken and adapted from https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/IPAddress.cs#L738
+        /// </summary>
+        /// <inheritdoc cref="IPAddress.MapToIPv4()"/>
+        public static IPAddress MapToIPv4(this IPAddress self)
+        {
+            if (self.AddressFamily == AddressFamily.InterNetwork)
+                return self;
+
+            byte[] addr = self.GetAddressBytes();
+            ushort[] numbers = new ushort[IPAddressParserStatics.IPv6AddressShorts];
+            for (int i = 0, byte_i = 0; i < IPAddressParserStatics.IPv6AddressShorts; i++, byte_i += 2)
+                numbers[i] = (ushort)((addr[byte_i + 1] << 8) & addr[byte_i]);
+            
+            return new IPAddress(((numbers[6] & 0x0000FF00u) >> 8) | ((numbers[6] & 0x000000FFu) << 8) | ((((numbers[7] & 0x0000FF00u) >> 8) | ((numbers[7] & 0x000000FFu) << 8)) << 16));
+        }
+
+        /// <summary>
+        /// Taken and adapted from https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/IPAddress.cs#L624
+        /// </summary>
+        /// <inheritdoc cref="IPAddress.IsIPv4MappedToIPv6()"/>
+        public static bool IsIPv4MappedToIPv6(this IPAddress self)
+        {
+            if (self.AddressFamily != AddressFamily.InterNetworkV6)
+                return false;
+
+            byte[] nums = self.GetAddressBytes();
+            for (int i = 0; i < 10; i++)
+                if (nums[i] != 0) return false;
+
+            return (nums[10] == 0xFF && nums[11] == 0xFF);
+        }
+#endif
+    }
+}

--- a/RiptideNetworking/RiptideNetworking/Utils/Framework35Compatibility.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Framework35Compatibility.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -71,18 +72,12 @@ namespace Riptide.Utils
         /// Taken and adapted from https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/IPAddress.cs#L738
         /// </summary>
         /// <inheritdoc cref="IPAddress.MapToIPv4()"/>
-        public static IPAddress MapToIPv4(this IPAddress self)
-        {
-            if (self.AddressFamily == AddressFamily.InterNetwork)
-                return self;
-
-            byte[] addr = self.GetAddressBytes();
-            ushort[] numbers = new ushort[IPAddressParserStatics.IPv6AddressShorts];
-            for (int i = 0, byte_i = 0; i < IPAddressParserStatics.IPv6AddressShorts; i++, byte_i += 2)
-                numbers[i] = (ushort)((addr[byte_i + 1] << 8) & addr[byte_i]);
-            
-            return new IPAddress(((numbers[6] & 0x0000FF00u) >> 8) | ((numbers[6] & 0x000000FFu) << 8) | ((((numbers[7] & 0x0000FF00u) >> 8) | ((numbers[7] & 0x000000FFu) << 8)) << 16));
-        }
+        public static IPAddress MapToIPv4(this IPAddress self) => self.AddressFamily == AddressFamily.InterNetwork
+                                                                      ? self
+                                                                      : new IPAddress(self.GetAddressBytes()
+                                                                                          .Skip(IPAddressParserStatics.IPv6AddressBytes - IPAddressParserStatics.IPv4AddressBytes)
+                                                                                          .ToArray());
+        
 
         /// <summary>
         /// Taken and adapted from https://github.com/microsoft/referencesource/blob/dae14279dd0672adead5de00ac8f117dcf74c184/System/net/System/Net/IPAddress.cs#L624


### PR DESCRIPTION
.NET Framework 3.5 was supported on versions before Unity 2018.3. This means that many games written in older versions of Unity that use this version of .NET are unable to use Riptide, which this pull requests fixes.

One new file was created, [`Framework35Compatability.cs`](https://github.com/WFIOST/Riptide/blob/main/RiptideNetworking/RiptideNetworking/Utils/Framework35Compatibility.cs) which adds extension methods for the parts that are missing in .NET framework 3.5. Some parts had to be copied and adapted from the current .NET source code, with attributions given (and is OK under the MIT license that this project and the .NET standard library falls under).

This is a draft PR until further testing (especially on the endianess) is done.