### PR TITLE
change Message.UnwrittenLength Access Modifier from internal to public

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -64,7 +64,7 @@ namespace Riptide
         /// <summary>The length in bytes of the data that has been written to the message.</summary>
         public int WrittenLength => writePos;
         /// <summary>How many more bytes can be written into the packet.</summary>
-        internal int UnwrittenLength => Bytes.Length - writePos;
+        public int UnwrittenLength => Bytes.Length - writePos;
         /// <summary>The message's data.</summary>
         internal byte[] Bytes { get; private set; }
 


### PR DESCRIPTION
UnwrittenLength is a useful helper function to access publicly.

I use it in my own project to help me decide when I need to break up data across multiple messages.

This PR only marks that property as public.