### PR TITLE
Fix OnClientDisconnected not invoked when Client in Pending state

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -457,8 +457,8 @@ namespace Riptide
             if (clients.Remove(client.Id))
                 availableClientIds.Enqueue(client.Id);
 
-            if (client.IsConnected)
-                OnClientDisconnected(client, reason); // Only run if the client was ever actually connected
+            if (client.IsConnected || client.IsPending)
+                OnClientDisconnected(client, reason); // Only run if the client was ever actually connected or in pending state (Accepted by the server AcceptConnection())
 
             client.LocalDisconnect();
         }


### PR DESCRIPTION
OnClientDisconnected not invoked when Client was in Pending state - accepted by the server but there was no Welcome response meaning that client state was not changed to Connected.