### PR TITLE
Fixed duplicate filtering, added "notify" message type, and reworked message sequencing

### DIFF
--- a/Demos/Console/ConsoleClient/Program.cs
+++ b/Demos/Console/ConsoleClient/Program.cs
@@ -1,4 +1,4 @@
-﻿using Riptide.Utils;
+using Riptide.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -57,13 +57,11 @@ namespace Riptide.Demos.ConsoleClient
 
         private static void Loop()
         {
-            client = new Client
-            {
-                TimeoutTime = ushort.MaxValue // Max value timeout to avoid getting timed out for as long as possible when testing with very high loss rates (if all heartbeat messages are lost during this period of time, it will trigger a disconnection)
-            };
+            client = new Client();
             client.Connected += (s, e) => Connected();
             client.Disconnected += (s, e) => Disconnected();
             client.Connect("127.0.0.1:7777");
+            client.Connection.CanTimeout = false; // Avoid getting timed out due to too many consecutive heartbeat messages being lost (which is possible when testing with very high loss rates)
 
             while (isRunning)
             {
@@ -179,7 +177,7 @@ namespace Riptide.Demos.ConsoleClient
             }
             else
                 Console.WriteLine("One-way reliability test complete! See server console for results.");
-            
+
             Console.WriteLine();
         }
 

--- a/Demos/Console/ConsoleServer/Program.cs
+++ b/Demos/Console/ConsoleServer/Program.cs
@@ -1,4 +1,4 @@
-﻿using Riptide.Utils;
+using Riptide.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -36,10 +36,8 @@ namespace Riptide.Demos.ConsoleServer
 
         private static void Loop()
         {
-            server = new Server
-            {
-                TimeoutTime = ushort.MaxValue // Max value timeout to avoid getting timed out for as long as possible when testing with very high loss rates (if all heartbeat messages are lost during this period of time, it will trigger a disconnection)
-            };
+            server = new Server();
+            server.ClientConnected += (s, e) => e.Client.CanTimeout = false; // Avoid clients getting timed out due to too many consecutive heartbeat messages being lost (which is possible when testing with very high loss rates)
             server.Start(7777, 10);
 
             while (isRunning)

--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -253,9 +253,6 @@ namespace Riptide
                 case MessageHeader.Ack:
                     connection.HandleAck(message);
                     break;
-                case MessageHeader.AckExtra:
-                    connection.HandleAckExtra(message);
-                    break;
                 case MessageHeader.Connect:
                     connection.SetPending();
                     break;

--- a/RiptideNetworking/RiptideNetworking/Connection.cs
+++ b/RiptideNetworking/RiptideNetworking/Connection.cs
@@ -253,7 +253,7 @@ namespace Riptide
         /// <param name="forSeqId">The sequence ID to acknowledge.</param>
         private void SendAck(ushort forSeqId)
         {
-            Message message = Message.Create(forSeqId == lastReceivedSeqId ? MessageHeader.Ack : MessageHeader.AckExtra);
+            Message message = Message.Create(MessageHeader.Ack);
             message.AddUShort(lastReceivedSeqId);
             message.AddUShort(receivedSeqIds.First16);
 
@@ -270,17 +270,7 @@ namespace Riptide
             ushort remoteLastReceivedSeqId = message.GetUShort();
             ushort remoteAcksBitField = message.GetUShort();
 
-            ClearMessage(remoteLastReceivedSeqId); // Immediately mark it as delivered so no resends are triggered while waiting for the sequence ID's bit to reach the end of the bit field
-            UpdateReceivedAcks(remoteLastReceivedSeqId, remoteAcksBitField);
-        }
-
-        /// <summary>Handles an ack message for a sequence ID other than the last received one.</summary>
-        /// <param name="message">The ack message to handle.</param>
-        internal void HandleAckExtra(Message message)
-        {
-            ushort remoteLastReceivedSeqId = message.GetUShort();
-            ushort remoteAcksBitField = message.GetUShort();
-            ushort ackedSeqId = message.GetUShort();
+            ushort ackedSeqId = message.UnreadLength > 0 ? message.GetUShort() : remoteLastReceivedSeqId;
 
             ClearMessage(ackedSeqId); // Immediately mark it as delivered so no resends are triggered while waiting for the sequence ID's bit to reach the end of the bit field
             UpdateReceivedAcks(remoteLastReceivedSeqId, remoteAcksBitField);

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -1,4 +1,4 @@
-﻿// This file is provided under The MIT License as part of RiptideNetworking.
+// This file is provided under The MIT License as part of RiptideNetworking.
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/tom-weiland/RiptideNetworking/blob/main/LICENSE.md
@@ -23,9 +23,17 @@ namespace Riptide
     /// <summary>Provides functionality for converting data to bytes and vice versa.</summary>
     public class Message
     {
+        /// <summary>The header size for unreliable messages. Does not count the 2 bytes used for the message ID.</summary>
+        /// <remarks>1 byte - header.</remarks>
+        internal const int UnreliableHeaderSize = 1;
+        /// <summary>The header size for reliable messages. Does not count the 2 bytes used for the message ID.</summary>
+        /// <remarks>1 byte - header, 2 bytes - sequence ID.</remarks>
+        internal const int ReliableHeaderSize = 3;
+        /// <summary>The header size for notify messages.</summary>
+        /// <remarks>1 byte - header, 3 bytes - ack, 2 bytes - sequence ID.</remarks>
+        internal const int NotifyHeaderSize = 6;
         /// <summary>The maximum number of bytes required for a message's header.</summary>
-        /// <remarks>1 byte for the actual header, 2 bytes for the sequence ID (only for reliable messages), 2 bytes for the message ID. Messages sent unreliably will use 2 bytes less than this value for the header.</remarks>
-        public const int MaxHeaderSize = 5;
+        public const int MaxHeaderSize = NotifyHeaderSize;
         /// <summary>The maximum number of bytes that a message can contain, including the <see cref="MaxHeaderSize"/>.</summary>
         public static int MaxSize { get; private set; } = MaxHeaderSize + 1225;
         /// <summary>The maximum number of bytes of payload data that a message can contain. This value represents how many bytes can be added to a message <i>on top of</i> the <see cref="MaxHeaderSize"/>.</summary>
@@ -135,6 +143,13 @@ namespace Riptide
             return RetrieveFromPool();
         }
 
+        /// <summary>Gets a notify message instance that can be used for sending.</summary>
+        /// <returns>A notify message instance ready to be sent.</returns>
+        public static Message CreateNotify()
+        {
+            return RetrieveFromPool().PrepareForUse(MessageHeader.Notify);
+        }
+
         /// <summary>Retrieves a message instance from the pool. If none is available, a new instance is created.</summary>
         /// <returns>A message instance ready to be used for sending or handling.</returns>
         private static Message RetrieveFromPool()
@@ -196,16 +211,22 @@ namespace Riptide
         internal void SetHeader(MessageHeader header)
         {
             Bytes[0] = (byte)header;
-            if (header >= MessageHeader.Reliable)
+            if (header == MessageHeader.Notify)
             {
-                readPos = 3;
-                writePos = 3;
+                readPos = NotifyHeaderSize;
+                writePos = NotifyHeaderSize;
+                SendMode = MessageSendMode.Unreliable; // Technically it's different but notify messages *are* still unreliable
+            }
+            else if (header >= MessageHeader.Reliable)
+            {
+                readPos = ReliableHeaderSize;
+                writePos = ReliableHeaderSize;
                 SendMode = MessageSendMode.Reliable;
             }
             else
             {
-                readPos = 1;
-                writePos = 1;
+                readPos = UnreliableHeaderSize;
+                writePos = UnreliableHeaderSize;
                 SendMode = MessageSendMode.Unreliable;
             }
         }

--- a/RiptideNetworking/RiptideNetworking/Peer.cs
+++ b/RiptideNetworking/RiptideNetworking/Peer.cs
@@ -180,24 +180,31 @@ namespace Riptide
 
             Message message = Message.CreateRaw();
             message.PrepareForUse(header, (ushort)e.Amount);
-
-            if (message.SendMode == MessageSendMode.Reliable)
+            
+            if (header == MessageHeader.Notify)
             {
-                if (e.Amount < 3) // Reliable messages have a 3 byte header, if there aren't that many bytes in the packet don't handle it
+                if (e.Amount < Message.NotifyHeaderSize)
                     return;
 
-                if (e.FromConnection.ReliableHandle(Converter.ToUShort(e.DataBuffer, 1)))
-                {
-                    Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1); // We've already established that the packet contains at least 3 bytes, and we always want to copy the sequence ID over
-                    messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));
-                }
+                e.FromConnection.ProcessNotify(e.DataBuffer, e.Amount, message);
             }
-            else
+            else if (message.SendMode == MessageSendMode.Unreliable)
             {
-                if (e.Amount > 1) // Only bother with the array copy if there is more than 1 byte in the packet (1 or less means no payload for a reliably sent packet)
+                if (e.Amount > Message.UnreliableHeaderSize) // Only bother with the array copy if there is more than 1 byte in the packet (1 or less means no payload for a reliably sent packet)
                     Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1);
 
                 messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));
+            }
+            else
+            {
+                if (e.Amount < Message.ReliableHeaderSize)
+                    return;
+
+                if (e.FromConnection.ShouldHandle(Converter.ToUShort(e.DataBuffer, 1)))
+                {
+                    Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1);
+                    messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));
+                }
             }
         }
 

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -334,9 +334,6 @@ namespace Riptide
                 case MessageHeader.Ack:
                     connection.HandleAck(message);
                     break;
-                case MessageHeader.AckExtra:
-                    connection.HandleAckExtra(message);
-                    break;
                 case MessageHeader.Connect:
                     HandleConnect(connection, message);
                     break;

--- a/RiptideNetworking/RiptideNetworking/Transports/IPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/IPeer.cs
@@ -14,8 +14,6 @@ namespace Riptide.Transports
         Unreliable,
         /// <summary>An internal unreliable ack message.</summary>
         Ack,
-        /// <summary>An internal unreliable ack message, used when acknowledging a sequence ID other than the last received one.</summary>
-        AckExtra,
         /// <summary>An internal unreliable connect message.</summary>
         Connect,
         /// <summary>An internal unreliable connection rejection message.</summary>

--- a/RiptideNetworking/RiptideNetworking/Transports/IPeer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/IPeer.cs
@@ -23,6 +23,9 @@ namespace Riptide.Transports
         /// <summary>An internal unreliable disconnect message.</summary>
         Disconnect,
 
+        /// <summary>A notify message.</summary>
+        Notify,
+
         /// <summary>A reliable user message.</summary>
         Reliable,
         /// <summary>An internal reliable welcome message.</summary>

--- a/RiptideNetworking/RiptideNetworking/Utils/Bitfield.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Bitfield.cs
@@ -1,0 +1,148 @@
+﻿// This file is provided under The MIT License as part of RiptideNetworking.
+// Copyright (c) Tom Weiland
+// For additional information please see the included LICENSE.md file or view it on GitHub:
+// https://github.com/tom-weiland/RiptideNetworking/blob/main/LICENSE.md
+
+using System;
+using System.Collections.Generic;
+
+namespace Riptide.Utils
+{
+    /// <summary>Provides functionality for managing and manipulating a collection of bits.</summary>
+    internal class Bitfield
+    {
+        /// <summary>The first 16 bits stored in the bitfield.</summary>
+        internal ushort First16 => (ushort)segments[0];
+
+        /// <summary>The number of bits which fit into a single segment.</summary>
+        private const int SegmentSize = sizeof(uint) * 8;
+        /// <summary>The segments of the bitfield.</summary>
+        private readonly List<uint> segments;
+        /// <summary>Whether or not the bitfield's capacity should dynamically adjust when shifting.</summary>
+        private readonly bool isDynamicCapacity;
+        /// <summary>The current number of bits being stored.</summary>
+        private int count;
+        /// <summary>The current capacity.</summary>
+        private int capacity;
+        
+        /// <summary>Creates a bitfield.</summary>
+        /// <param name="isDynamicCapacity">Whether or not the bitfield's capacity should dynamically adjust when shifting.</param>
+        internal Bitfield(bool isDynamicCapacity = true)
+        {
+            segments = new List<uint>(4) { 0 };
+            capacity = segments.Count * SegmentSize;
+            this.isDynamicCapacity = isDynamicCapacity;
+        }
+
+        /// <summary>Checks if the bitfield has capacity for the given number of bits.</summary>
+        /// <param name="amount">The number of bits for which to check if there is capacity.</param>
+        /// <param name="overflow">The number of bits from <paramref name="amount"/> which there is no capacity for.</param>
+        /// <returns>Whether or not there is sufficient capacity.</returns>
+        internal bool HasCapacityFor(int amount, out int overflow)
+        {
+            overflow = count + amount - capacity;
+            return overflow < 0;
+        }
+
+        /// <summary>Shifts the bitfield by the given amount.</summary>
+        /// <param name="amount">How much to shift by.</param>
+        internal void ShiftBy(int amount)
+        {
+            int segmentShift = amount / SegmentSize; // How many WHOLE segments we have to shift by
+            int bitShift = amount % SegmentSize; // How many bits we have to shift by
+
+            if (!isDynamicCapacity)
+                count = Math.Min(count + amount, SegmentSize);
+            else if (!HasCapacityFor(amount, out int _))
+            {
+                Trim();
+                count += amount;
+
+                if (count > capacity)
+                {
+                    int increaseBy = segmentShift + 1;
+                    for (int i = 0; i < increaseBy; i++)
+                        segments.Add(0);
+
+                    capacity = segments.Count * SegmentSize;
+                }
+            }
+            else
+                count += amount;
+
+            int s = segments.Count - 1;
+            segments[s] <<= bitShift;
+            s -= 1 + segmentShift;
+            while (s > -1)
+            {
+                ulong shiftedBits = (ulong)segments[s] << bitShift;
+                segments[s] = (uint)shiftedBits;
+
+                segments[s + 1 + segmentShift] |= (uint)(shiftedBits >> SegmentSize);
+                s--;
+            }
+        }
+
+        /// <summary>Checks the last bit in the bitfield, and trims it if it is set to 1.</summary>
+        /// <param name="checkedPosition">The checked bit's position in the bitfield.</param>
+        /// <returns>Whether or not the checked bit was set.</returns>
+        internal bool CheckAndTrimLast(out int checkedPosition)
+        {
+            checkedPosition = count;
+            uint bitToCheck = (uint)(1 << ((count - 1) % SegmentSize));
+            bool isSet = (segments[segments.Count - 1] & bitToCheck) != 0;
+            count--;
+            return isSet;
+        }
+
+        /// <summary>Trims all bits from the end of the bitfield until an unset bit is encountered.</summary>
+        private void Trim()
+        {
+            while (count > 0 && IsSet(count))
+                count--;
+        }
+
+        /// <summary>Sets the given bit to 1.</summary>
+        /// <param name="bit">The bit to set.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is less than 1.</exception>
+        internal void Set(int bit)
+        {
+            if (bit < 1)
+                throw new ArgumentOutOfRangeException(nameof(bit), $"'{nameof(bit)}' must be greater than zero!");
+
+            bit--;
+            int s = bit / SegmentSize;
+            uint bitToSet = (uint)(1 << (bit % SegmentSize));
+            if (s < segments.Count)
+                segments[s] |= bitToSet;
+        }
+
+        /// <summary>Checks if the given bit is set to 1.</summary>
+        /// <param name="bit">The bit to check.</param>
+        /// <returns>Whether or not the bit is set.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="bit"/> is less than 1.</exception>
+        internal bool IsSet(int bit)
+        {
+            if (bit > count)
+                return true;
+
+            if (bit < 1)
+                throw new ArgumentOutOfRangeException(nameof(bit), $"'{nameof(bit)}' must be greater than zero!");
+
+            bit--;
+            int s = bit / SegmentSize;
+            uint bitToCheck = (uint)(1 << (bit % SegmentSize));
+            if (s < segments.Count)
+                return (segments[s] & bitToCheck) != 0;
+
+            return true;
+        }
+
+        /// <summary>Combines this bitfield with the given bits.</summary>
+        /// <param name="other">The bits to OR into the bitfield.</param>
+        internal void Combine(ushort other)
+        {
+            segments[0] |= other;
+        }
+    }
+}

--- a/RiptideNetworking/RiptideNetworking/Utils/Bitfield.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Bitfield.cs
@@ -11,6 +11,8 @@ namespace Riptide.Utils
     /// <summary>Provides functionality for managing and manipulating a collection of bits.</summary>
     internal class Bitfield
     {
+        /// <summary>The first 8 bits stored in the bitfield.</summary>
+        internal byte First8 => (byte)segments[0];
         /// <summary>The first 16 bits stored in the bitfield.</summary>
         internal ushort First16 => (ushort)segments[0];
 


### PR DESCRIPTION
Previously, duplicate filtering was...*finicky*. The duplicate filter was a fixed size, and sending too many messages too quickly could cause it to overflow, resulting in messages being handled when they shouldn't be.

This is a complete overhaul of the duplicate filtering system which makes it capable of adjusting its size as necessary to avoid overflowing.

This PR also adds a new "notify" message type, which is somewhat of a middle ground between reliable and unreliable messages. Notify messages act like unreliable messages in the sense that they are not stored and automatically resent when loss is detected. However, they differ in that they get a sequence ID and loss/delivery is tracked & reported via events in the `Connection` class, allowing the user to decide what to do in those circumstances.

In the process of adding notify messages, the sequencing system got an overhaul too.