### PR TITLE
Add error log on attempt to connect using non-empty message

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -127,6 +127,9 @@ namespace Riptide
 
             if (message != null)
             {
+                if (message.WrittenLength != message.UnreadLength)
+                    RiptideLogger.Log(LogType.Error, LogName, $"Message for connection {connection} already have read data. Please make sure empty message instance without {nameof(MessageSendMode)} or message ID is used.");
+                
                 connectBytes = message.GetBytes(message.WrittenLength);
                 message.Release();
             }


### PR DESCRIPTION
Just small change adding an error log - I think extra explanation what happens and what should be done when trying to connect with non-empty message (for example made using `Message.Create(MessageSendMode.Reliable, 0)` instead of `Message.Create()`) could be useful to save other programmers some debugging.

I've noticed this issue being mentioned previously in the past: https://github.com/RiptideNetworking/Riptide/issues/65 