### PR TITLE
Reworked the Message class to operate on the bit level (as opposed to the byte leve)

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -70,8 +70,8 @@ namespace Riptide
         private Dictionary<ushort, MessageHandler> messageHandlers;
         /// <summary>The underlying transport's client that is used for sending and receiving data.</summary>
         private IClient transport;
-        /// <summary>Custom data to include when connecting.</summary>
-        private byte[] connectBytes;
+        /// <summary>The message sent when connecting. May include custom data.</summary>
+        private Message connectMessage;
 
         /// <summary>Handles initial setup.</summary>
         /// <param name="transport">The transport to use for sending and receiving data.</param>
@@ -125,16 +125,15 @@ namespace Riptide
             if (useMessageHandlers)
                 CreateMessageHandlersDictionary(messageHandlerGroupId);
 
+            connectMessage = Message.Create(MessageHeader.Connect);
             if (message != null)
             {
                 if (message.ReadBits != 0)
                     RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when setting connection attempt data!");
 
-                connectBytes = message.GetBytes(message.BytesInUse);
+                connectMessage.AddMessage(message);
                 message.Release();
             }
-            else
-                connectBytes = null;
 
             StartTime();
             Heartbeat();
@@ -204,11 +203,7 @@ namespace Riptide
                 // If still trying to connect, send connect messages instead of heartbeats
                 if (connectionAttempts < maxConnectionAttempts)
                 {
-                    Message message = Message.Create(MessageHeader.Connect);
-                    if (connectBytes != null)
-                        message.AddBytes(connectBytes, false);
-
-                    Send(message);
+                    Send(connectMessage, false);
                     connectionAttempts++;
                 }
                 else
@@ -366,6 +361,8 @@ namespace Riptide
         /// <summary>Invokes the <see cref="Connected"/> event.</summary>
         protected virtual void OnConnected()
         {
+            connectMessage.Release();
+            connectMessage = null;
             RiptideLogger.Log(LogType.Info, LogName, "Connected successfully!");
             Connected?.Invoke(this, EventArgs.Empty);
         }
@@ -375,6 +372,8 @@ namespace Riptide
         /// <param name="message">Additional data related to the failed connection attempt.</param>
         protected virtual void OnConnectionFailed(RejectReason reason, Message message = null)
         {
+            connectMessage.Release();
+            connectMessage = null;
             RiptideLogger.Log(LogType.Info, LogName, $"Connection to server failed: {Helper.GetReasonString(reason)}.");
             ConnectionFailed?.Invoke(this, new ConnectionFailedEventArgs(reason, message));
         }

--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -127,10 +127,10 @@ namespace Riptide
 
             if (message != null)
             {
-                if (message.ReadLength != 0)
-                    RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when including data with a connection attempt!");
-                
-                connectBytes = message.GetBytes(message.WrittenLength);
+                if (message.ReadBits != 0)
+                    RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when setting connection attempt data!");
+
+                connectBytes = message.GetBytes(message.BytesInUse);
                 message.Release();
             }
             else
@@ -288,7 +288,7 @@ namespace Riptide
                     OnClientDisconnected(message.GetUShort());
                     break;
                 default:
-                    RiptideLogger.Log(LogType.Warning, LogName, $"Unexpected message header '{header}'! Discarding {message.WrittenLength} bytes.");
+                    RiptideLogger.Log(LogType.Warning, LogName, $"Unexpected message header '{header}'! Discarding {message.BytesInUse} bytes.");
                     break;
             }
 

--- a/RiptideNetworking/RiptideNetworking/Connection.cs
+++ b/RiptideNetworking/RiptideNetworking/Connection.cs
@@ -1,4 +1,4 @@
-// This file is provided under The MIT License as part of RiptideNetworking.
+﻿// This file is provided under The MIT License as part of RiptideNetworking.
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
@@ -151,7 +151,8 @@ namespace Riptide
             if (message.SendMode == MessageSendMode.Unreliable)
             {
                 int byteAmount = message.BytesInUse;
-                Send(message.Bytes, byteAmount);
+                Buffer.BlockCopy(message.Data, 0, Message.ByteBuffer, 0, byteAmount);
+                Send(Message.ByteBuffer, byteAmount);
                 Metrics.SentUnreliable(byteAmount);
             }
             else
@@ -175,7 +176,8 @@ namespace Riptide
         {
             ushort sequenceId = notify.InsertHeader(message);
             int byteAmount = message.BytesInUse;
-            Send(message.Bytes, byteAmount);
+            Buffer.BlockCopy(message.Data, 0, Message.ByteBuffer, 0, byteAmount);
+            Send(Message.ByteBuffer, byteAmount);
             Metrics.SentNotify(byteAmount);
 
             if (shouldRelease)
@@ -200,7 +202,7 @@ namespace Riptide
             Metrics.ReceivedNotify(amount);
             if (notify.ShouldHandle(Converter.UShortFromBits(dataBuffer, Message.HeaderBits + 24)))
             {
-                Array.Copy(dataBuffer, 1, message.Bytes, 1, amount - 1); // Copy payload
+                Buffer.BlockCopy(dataBuffer, 1, message.Data, 1, amount - 1); // Copy payload
                 NotifyReceived?.Invoke(message);
             }
             else
@@ -481,8 +483,8 @@ namespace Riptide
             internal ushort InsertHeader(Message message)
             {
                 ushort sequenceId = NextSequenceId;
-                ulong notifyBits = lastReceivedSeqId | ((ulong)receivedSeqIds.First8 << (2 * Message.BitsPerByte)) | ((ulong)sequenceId << (3 * Message.BitsPerByte));
-                message.SetBits(notifyBits, 5 * Message.BitsPerByte, Message.HeaderBits);
+                ulong notifyBits = lastReceivedSeqId | ((ulong)receivedSeqIds.First8 << (2 * Converter.BitsPerByte)) | ((ulong)sequenceId << (3 * Converter.BitsPerByte));
+                message.SetBits(notifyBits, 5 * Converter.BitsPerByte, Message.HeaderBits);
                 return sequenceId;
             }
 

--- a/RiptideNetworking/RiptideNetworking/Exceptions.cs
+++ b/RiptideNetworking/RiptideNetworking/Exceptions.cs
@@ -9,15 +9,15 @@ using System.Reflection;
 
 namespace Riptide
 {
-    /// <summary>The exception that is thrown when a <see cref="Message"/> does not contain enough unread bytes to add a certain value.</summary>
+    /// <summary>The exception that is thrown when a <see cref="Message"/> does not contain enough unwritten bits to add a certain value.</summary>
     public class InsufficientCapacityException : Exception
     {
         /// <summary>The message with insufficient remaining capacity.</summary>
         public readonly Message RiptideMessage;
         /// <summary>The name of the type which could not be added to the message.</summary>
         public readonly string TypeName;
-        /// <summary>The number of available bytes the type requires in order to be added successfully.</summary>
-        public readonly int RequiredBytes;
+        /// <summary>The number of available bits the type requires in order to be added successfully.</summary>
+        public readonly int RequiredBits;
 
         /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance.</summary>
         public InsufficientCapacityException() { }
@@ -31,42 +31,39 @@ namespace Riptide
         /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance and constructs an error message from the given information.</summary>
         /// <param name="message">The message with insufficient remaining capacity.</param>
         /// <param name="typeName">The name of the type which could not be added to the message.</param>
-        /// <param name="requiredBytes">The number of available bytes required for the type to be added successfully.</param>
-        public InsufficientCapacityException(Message message, string typeName, int requiredBytes) : base(GetErrorMessage(message, typeName, requiredBytes))
+        /// <param name="requiredBits">The number of available bits required for the type to be added successfully.</param>
+        public InsufficientCapacityException(Message message, string typeName, int requiredBits) : base(GetErrorMessage(message, typeName, requiredBits))
         {
             RiptideMessage = message;
-            RequiredBytes = requiredBytes;
+            RequiredBits = requiredBits;
             TypeName = typeName;
         }
         /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance and constructs an error message from the given information.</summary>
         /// <param name="message">The message with insufficient remaining capacity.</param>
         /// <param name="arrayLength">The length of the array which could not be added to the message.</param>
         /// <param name="typeName">The name of the array's type.</param>
-        /// <param name="requiredBytes">The number of available bytes required for a single element of the array to be added successfully.</param>
-        /// <param name="totalRequiredBytes">The number of available bytes required for the entire array to be added successfully. If left as -1, this will be set to <paramref name="arrayLength"/> * <paramref name="requiredBytes"/>.</param>
-        public InsufficientCapacityException(Message message, int arrayLength, string typeName, int requiredBytes, int totalRequiredBytes = -1) : base(GetErrorMessage(message, arrayLength, typeName, requiredBytes, totalRequiredBytes))
+        /// <param name="requiredBits">The number of available bits required for a single element of the array to be added successfully.</param>
+        public InsufficientCapacityException(Message message, int arrayLength, string typeName, int requiredBits) : base(GetErrorMessage(message, arrayLength, typeName, requiredBits))
         {
             RiptideMessage = message;
-            RequiredBytes = totalRequiredBytes == -1 ? arrayLength * requiredBytes : totalRequiredBytes;
+            RequiredBits = requiredBits * arrayLength;
             TypeName = $"{typeName}[]";
         }
 
         /// <summary>Constructs the error message from the given information.</summary>
         /// <returns>The error message.</returns>
-        private static string GetErrorMessage(Message message, string typeName, int requiredBytes)
+        private static string GetErrorMessage(Message message, string typeName, int requiredBits)
         {
-            return $"Cannot add a value of type '{typeName}' (requires {requiredBytes} {Helper.CorrectForm(requiredBytes, "byte")}) to " +
-                   $"a message with {message.UnwrittenLength} {Helper.CorrectForm(message.UnwrittenLength, "byte")} of remaining capacity!";
+            return $"Cannot add a value of type '{typeName}' (requires {requiredBits} {Helper.CorrectForm(requiredBits, "bit")}) to " +
+                   $"a message with {message.UnwrittenBits} {Helper.CorrectForm(message.UnwrittenBits, "bit")} of remaining capacity!";
         }
         /// <summary>Constructs the error message from the given information.</summary>
         /// <returns>The error message.</returns>
-        private static string GetErrorMessage(Message message, int arrayLength, string typeName, int requiredBytes, int totalRequiredBytes)
+        private static string GetErrorMessage(Message message, int arrayLength, string typeName, int requiredBits)
         {
-            if (totalRequiredBytes == -1)
-                totalRequiredBytes = arrayLength * requiredBytes;
-
-            return $"Cannot add an array of type '{typeName}[]' with {arrayLength} {Helper.CorrectForm(arrayLength, "element")} (requires {totalRequiredBytes} {Helper.CorrectForm(totalRequiredBytes, "byte")}) " +
-                   $"to a message with {message.UnwrittenLength} {Helper.CorrectForm(message.UnwrittenLength, "byte")} of remaining capacity!";
+            requiredBits *= arrayLength;
+            return $"Cannot add an array of type '{typeName}[]' with {arrayLength} {Helper.CorrectForm(arrayLength, "element")} (requires {requiredBits} {Helper.CorrectForm(requiredBits, "bit")}) " +
+                   $"to a message with {message.UnwrittenBits} {Helper.CorrectForm(message.UnwrittenBits, "bit")} of remaining capacity!";
         }
     }
     

--- a/RiptideNetworking/RiptideNetworking/Exceptions.cs
+++ b/RiptideNetworking/RiptideNetworking/Exceptions.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 
 namespace Riptide
 {
-    /// <summary>The exception that is thrown when a <see cref="Message"/> does not contain enough unwritten bits to add a certain value.</summary>
+    /// <summary>The exception that is thrown when a <see cref="Message"/> does not contain enough unwritten bits to perform an operation.</summary>
     public class InsufficientCapacityException : Exception
     {
         /// <summary>The message with insufficient remaining capacity.</summary>
@@ -30,13 +30,22 @@ namespace Riptide
         public InsufficientCapacityException(string message, Exception inner) : base(message, inner) { }
         /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance and constructs an error message from the given information.</summary>
         /// <param name="message">The message with insufficient remaining capacity.</param>
+        /// <param name="reserveBits">The number of bits which were attempted to be reserved.</param>
+        public InsufficientCapacityException(Message message, int reserveBits) : base(GetErrorMessage(message, reserveBits))
+        {
+            RiptideMessage = message;
+            TypeName = "reservation";
+            RequiredBits = reserveBits;
+        }
+        /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance and constructs an error message from the given information.</summary>
+        /// <param name="message">The message with insufficient remaining capacity.</param>
         /// <param name="typeName">The name of the type which could not be added to the message.</param>
         /// <param name="requiredBits">The number of available bits required for the type to be added successfully.</param>
         public InsufficientCapacityException(Message message, string typeName, int requiredBits) : base(GetErrorMessage(message, typeName, requiredBits))
         {
             RiptideMessage = message;
-            RequiredBits = requiredBits;
             TypeName = typeName;
+            RequiredBits = requiredBits;
         }
         /// <summary>Initializes a new <see cref="InsufficientCapacityException"/> instance and constructs an error message from the given information.</summary>
         /// <param name="message">The message with insufficient remaining capacity.</param>
@@ -46,10 +55,17 @@ namespace Riptide
         public InsufficientCapacityException(Message message, int arrayLength, string typeName, int requiredBits) : base(GetErrorMessage(message, arrayLength, typeName, requiredBits))
         {
             RiptideMessage = message;
-            RequiredBits = requiredBits * arrayLength;
             TypeName = $"{typeName}[]";
+            RequiredBits = requiredBits * arrayLength;
         }
 
+        /// <summary>Constructs the error message from the given information.</summary>
+        /// <returns>The error message.</returns>
+        private static string GetErrorMessage(Message message, int reserveBits)
+        {
+            return $"Cannot reserve {reserveBits} {Helper.CorrectForm(reserveBits, "bit")} in a message with {message.UnwrittenBits} " +
+                   $"{Helper.CorrectForm(message.UnwrittenBits, "bit")} of remaining capacity!";
+        }
         /// <summary>Constructs the error message from the given information.</summary>
         /// <returns>The error message.</returns>
         private static string GetErrorMessage(Message message, string typeName, int requiredBits)

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -327,8 +327,8 @@ namespace Riptide
         {
             if (UnreadBits < BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ByteName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ByteName, $"{default(byte)}"));
+                return default;
             }
 
             byte value = Converter.ByteFromBits(Bytes, readBit);
@@ -342,8 +342,8 @@ namespace Riptide
         {
             if (UnreadBits < BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(SByteName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(SByteName, $"{default(sbyte)}"));
+                return default;
             }
 
             sbyte value = Converter.SByteFromBits(Bytes, readBit);
@@ -515,8 +515,8 @@ namespace Riptide
         {
             if (UnreadBits < 1)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(BoolName, "false"));
-                return false;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(BoolName, $"{default(bool)}"));
+                return default;
             }
 
             return Converter.BoolFromBit(Bytes, readBit++);
@@ -614,8 +614,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(short) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ShortName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ShortName, $"{default(short)}"));
+                return default;
             }
 
             short value = Converter.ShortFromBits(Bytes, readBit);
@@ -629,8 +629,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(ushort) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UShortName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UShortName, $"{default(ushort)}"));
+                return default;
             }
 
             ushort value = Converter.UShortFromBits(Bytes, readBit);
@@ -800,8 +800,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(int) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(IntName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(IntName, $"{default(int)}"));
+                return default;
             }
 
             int value = Converter.IntFromBits(Bytes, readBit);
@@ -815,8 +815,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(uint) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UIntName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UIntName, $"{default(uint)}"));
+                return default;
             }
 
             uint value = Converter.UIntFromBits(Bytes, readBit);
@@ -986,8 +986,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(long) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(LongName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(LongName, $"{default(long)}"));
+                return default;
             }
 
             long value = Converter.LongFromBits(Bytes, readBit);
@@ -1001,8 +1001,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(ulong) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ULongName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ULongName, $"{default(ulong)}"));
+                return default;
             }
 
             ulong value = Converter.ULongFromBits(Bytes, readBit);
@@ -1159,8 +1159,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(float) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(FloatName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(FloatName, $"{default(float)}"));
+                return default;
             }
 
             float value = Converter.FloatFromBits(Bytes, readBit);
@@ -1253,8 +1253,8 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(double) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(DoubleName));
-                return 0;
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(DoubleName, $"{default(double)}"));
+                return default;
             }
 
             double value = Converter.DoubleFromBits(Bytes, readBit);
@@ -1443,7 +1443,7 @@ namespace Riptide
         {
             if (UnreadBits < BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ArrayLengthName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ArrayLengthName, "0"));
                 return 0;
             }
 
@@ -1459,7 +1459,7 @@ namespace Riptide
             
             if (UnreadBits < sizeof(ushort) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ArrayLengthName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ArrayLengthName, "0"));
                 return 0;
             }
 
@@ -1655,7 +1655,7 @@ namespace Riptide
         /// <param name="valueName">The name of the value type for which the retrieval attempt failed.</param>
         /// <param name="defaultReturn">Text describing the value which will be returned.</param>
         /// <returns>The error message.</returns>
-        private string NotEnoughBitsError(string valueName, string defaultReturn = "0")
+        private string NotEnoughBitsError(string valueName, string defaultReturn)
         {
             return $"Message only contains {UnreadBits} unread {Helper.CorrectForm(UnreadBits, "bit")}, which is not enough to retrieve a value of type '{valueName}'! Returning {defaultReturn}.";
         }

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -279,12 +279,12 @@ namespace Riptide
         }
 
         /// <summary>Sets up to 8 bits at the specified position in the message.</summary>
-        /// <param name="bitfield">The bitfield from which to write the bits into the message.</param>
+        /// <param name="bitfield">The bits to write into the message.</param>
         /// <param name="amount">The number of bits to set.</param>
         /// <param name="startBit">The bit position in the message at which to start writing.</param>
         /// <returns>The message instance.</returns>
-        /// <remarks>This method can be used to directly set a range of bits without moving the message's internal write position. Data which was previously added to the message
-        /// and which falls within the range of bits being set will be <i>overwritten</i>, meaning that improper use of this method will likely corrupt the message!</remarks>
+        /// <remarks>This method can be used to directly set a range of bits anywhere in the message without moving its internal write position. Data which was previously added to
+        /// the message and which falls within the range of bits being set will be <i>overwritten</i>, meaning that improper use of this method will likely corrupt the message!</remarks>
         public Message SetBits(byte bitfield, int amount, int startBit)
         {
             if (amount > BitsPerByte)
@@ -321,6 +321,137 @@ namespace Riptide
                 throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(SetBits)}' overload cannot be used to set more than {sizeof(ulong) * BitsPerByte} bits at a time!");
 
             Converter.SetBits(bitfield, amount, Bytes, startBit);
+            return this;
+        }
+
+        /// <summary>Retrieves up to 8 bits from the specified position in the message.</summary>
+        /// <param name="amount">The number of bits to peek.</param>
+        /// <param name="startBit">The bit position in the message at which to start peeking.</param>
+        /// <param name="bitfield">The bits that were retrieved.</param>
+        /// <returns>The message instance.</returns>
+        /// <remarks>This method can be used to retrieve a range of bits from anywhere in the message without moving its internal read position.</remarks>
+        public Message PeekBits(int amount, int startBit, out byte bitfield)
+        {
+            if (amount > BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(PeekBits)}' overload cannot be used to peek more than {BitsPerByte} bits at a time!");
+
+            Converter.GetBits(amount, Bytes, startBit, out bitfield);
+            return this;
+        }
+        /// <summary>Retrieves up to 16 bits from the specified position in the message.</summary>
+        /// <inheritdoc cref="PeekBits(int, int, out byte)"/>
+        public Message PeekBits(int amount, int startBit, out ushort bitfield)
+        {
+            if (amount > sizeof(ushort) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(PeekBits)}' overload cannot be used to peek more than {sizeof(ushort) * BitsPerByte} bits at a time!");
+
+            Converter.GetBits(amount, Bytes, startBit, out bitfield);
+            return this;
+        }
+        /// <summary>Retrieves up to 32 bits from the specified position in the message.</summary>
+        /// <inheritdoc cref="PeekBits(int, int, out byte)"/>
+        public Message PeekBits(int amount, int startBit, out uint bitfield)
+        {
+            if (amount > sizeof(uint) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(PeekBits)}' overload cannot be used to peek more than {sizeof(uint) * BitsPerByte} bits at a time!");
+
+            Converter.GetBits(amount, Bytes, startBit, out bitfield);
+            return this;
+        }
+        /// <summary>Retrieves up to 64 bits from the specified position in the message.</summary>
+        /// <inheritdoc cref="PeekBits(int, int, out byte)"/>
+        public Message PeekBits(int amount, int startBit, out ulong bitfield)
+        {
+            if (amount > sizeof(ulong) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(PeekBits)}' overload cannot be used to peek more than {sizeof(ulong) * BitsPerByte} bits at a time!");
+
+            Converter.GetBits(amount, Bytes, startBit, out bitfield);
+            return this;
+        }
+
+        /// <summary>Adds up to 8 of the given bits to the message.</summary>
+        /// <param name="bitfield">The bits to add.</param>
+        /// <param name="amount">The number of bits to add.</param>
+        /// <returns>The message that the bits were added to.</returns>
+        public Message AddBits(byte bitfield, int amount)
+        {
+            if (amount > BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(AddBits)}' overload cannot be used to add more than {BitsPerByte} bits at a time!");
+
+            bitfield &= (byte)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're setting
+            Converter.ByteToBits(bitfield, Bytes, writeBit);
+            writeBit += amount;
+            return this;
+        }
+        /// <summary>Adds up to 16 of the given bits to the message.</summary>
+        /// <inheritdoc cref="AddBits(byte, int)"/>
+        public Message AddBits(ushort bitfield, int amount)
+        {
+            if (amount > sizeof(ushort) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(AddBits)}' overload cannot be used to add more than {sizeof(ushort) * BitsPerByte} bits at a time!");
+
+            bitfield &= (ushort)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're adding
+            Converter.UShortToBits(bitfield, Bytes, writeBit);
+            writeBit += amount;
+            return this;
+        }
+        /// <summary>Adds up to 32 of the given bits to the message.</summary>
+        /// <inheritdoc cref="AddBits(byte, int)"/>
+        public Message AddBits(uint bitfield, int amount)
+        {
+            if (amount > sizeof(uint) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(AddBits)}' overload cannot be used to add more than {sizeof(uint) * BitsPerByte} bits at a time!");
+
+            bitfield &= (1u << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're adding
+            Converter.UIntToBits(bitfield, Bytes, writeBit);
+            writeBit += amount;
+            return this;
+        }
+        /// <summary>Adds up to 64 of the given bits to the message.</summary>
+        /// <inheritdoc cref="AddBits(byte, int)"/>
+        public Message AddBits(ulong bitfield, int amount)
+        {
+            if (amount > sizeof(ulong) * BitsPerByte)
+                throw new ArgumentOutOfRangeException(nameof(amount), $"This '{nameof(AddBits)}' overload cannot be used to add more than {sizeof(ulong) * BitsPerByte} bits at a time!");
+
+            bitfield &= (1ul << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're adding
+            Converter.ULongToBits(bitfield, Bytes, writeBit);
+            writeBit += amount;
+            return this;
+        }
+
+        /// <summary>Retrieves the next <paramref name="amount"/> bits (up to 8) from the message.</summary>
+        /// <param name="amount">The number of bits to retrieve.</param>
+        /// <param name="bitfield">The bits that were retrieved.</param>
+        /// <returns>The messages that the bits were retrieved from.</returns>
+        public Message GetBits(int amount, out byte bitfield)
+        {
+            PeekBits(amount, readBit, out bitfield);
+            readBit += amount;
+            return this;
+        }
+        /// <summary>Retrieves the next <paramref name="amount"/> bits (up to 16) from the message.</summary>
+        /// <inheritdoc cref="GetBits(int, out byte)"/>
+        public Message GetBits(int amount, out ushort bitfield)
+        {
+            PeekBits(amount, readBit, out bitfield);
+            readBit += amount;
+            return this;
+        }
+        /// <summary>Retrieves the next <paramref name="amount"/> bits (up to 32) from the message.</summary>
+        /// <inheritdoc cref="GetBits(int, out byte)"/>
+        public Message GetBits(int amount, out uint bitfield)
+        {
+            PeekBits(amount, readBit, out bitfield);
+            readBit += amount;
+            return this;
+        }
+        /// <summary>Retrieves the next <paramref name="amount"/> bits (up to 64) from the message.</summary>
+        /// <inheritdoc cref="GetBits(int, out byte)"/>
+        public Message GetBits(int amount, out ulong bitfield)
+        {
+            PeekBits(amount, readBit, out bitfield);
+            readBit += amount;
             return this;
         }
         #endregion

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -1691,82 +1691,108 @@ namespace Riptide
         #region Overload Versions
         /// <inheritdoc cref="AddByte(byte)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddByte(byte)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(byte value) => AddByte(value);
         /// <inheritdoc cref="AddSByte(sbyte)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddSByte(sbyte)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(sbyte value) => AddSByte(value);
         /// <inheritdoc cref="AddBool(bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddBool(bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(bool value) => AddBool(value);
         /// <inheritdoc cref="AddShort(short)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddShort(short)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(short value) => AddShort(value);
         /// <inheritdoc cref="AddUShort(ushort)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddUShort(ushort)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(ushort value) => AddUShort(value);
         /// <inheritdoc cref="AddInt(int)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddInt(int)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(int value) => AddInt(value);
         /// <inheritdoc cref="AddUInt(uint)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddUInt(uint)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(uint value) => AddUInt(value);
         /// <inheritdoc cref="AddLong(long)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddLong(long)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(long value) => AddLong(value);
         /// <inheritdoc cref="AddULong(ulong)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddULong(ulong)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(ulong value) => AddULong(value);
         /// <inheritdoc cref="AddFloat(float)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddFloat(float)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(float value) => AddFloat(value);
         /// <inheritdoc cref="AddDouble(double)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddDouble(double)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(double value) => AddDouble(value);
         /// <inheritdoc cref="AddString(string)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddString(string)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(string value) => AddString(value);
         /// <inheritdoc cref="AddSerializable{T}(T)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddSerializable{T}(T)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add<T>(T value) where T : IMessageSerializable => AddSerializable(value);
 
         /// <inheritdoc cref="AddBytes(byte[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddBytes(byte[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(byte[] array, bool includeLength = true) => AddBytes(array, includeLength);
         /// <inheritdoc cref="AddSBytes(sbyte[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddSBytes(sbyte[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(sbyte[] array, bool includeLength = true) => AddSBytes(array, includeLength);
         /// <inheritdoc cref="AddBools(bool[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddBools(bool[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(bool[] array, bool includeLength = true) => AddBools(array, includeLength);
         /// <inheritdoc cref="AddShorts(short[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddShorts(short[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(short[] array, bool includeLength = true) => AddShorts(array, includeLength);
         /// <inheritdoc cref="AddUShorts(ushort[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddUShorts(ushort[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(ushort[] array, bool includeLength = true) => AddUShorts(array, includeLength);
         /// <inheritdoc cref="AddInts(int[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddInts(int[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(int[] array, bool includeLength = true) => AddInts(array, includeLength);
         /// <inheritdoc cref="AddUInts(uint[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddUInts(uint[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(uint[] array, bool includeLength = true) => AddUInts(array, includeLength);
         /// <inheritdoc cref="AddLongs(long[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddLongs(long[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(long[] array, bool includeLength = true) => AddLongs(array, includeLength);
         /// <inheritdoc cref="AddULongs(ulong[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddULongs(ulong[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(ulong[] array, bool includeLength = true) => AddULongs(array, includeLength);
         /// <inheritdoc cref="AddFloats(float[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddFloats(float[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(float[] array, bool includeLength = true) => AddFloats(array, includeLength);
         /// <inheritdoc cref="AddDoubles(double[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddDoubles(double[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(double[] array, bool includeLength = true) => AddDoubles(array, includeLength);
         /// <inheritdoc cref="AddStrings(string[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddStrings(string[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add(string[] array, bool includeLength = true) => AddStrings(array, includeLength);
         /// <inheritdoc cref="AddSerializables{T}(T[], bool)"/>
         /// <remarks>This method is simply an alternative way of calling <see cref="AddSerializables{T}(T[], bool)"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Message Add<T>(T[] array, bool includeLength = true) where T : IMessageSerializable, new() => AddSerializables(array, includeLength);
         #endregion
         #endregion

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -457,7 +457,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, ByteName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ByteName));
                 amount = UnreadBits / BitsPerByte;
             }
 
@@ -484,7 +484,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, SByteName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, SByteName));
                 amount = UnreadBits / BitsPerByte;
             }
 
@@ -736,7 +736,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(short) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, ShortName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ShortName));
                 amount = UnreadBits / (sizeof(short) * BitsPerByte);
             }
 
@@ -755,7 +755,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(ushort) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, UShortName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UShortName));
                 amount = UnreadBits / (sizeof(ushort) * BitsPerByte);
             }
 
@@ -922,7 +922,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(int) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, IntName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, IntName));
                 amount = UnreadBits / (sizeof(int) * BitsPerByte);
             }
 
@@ -941,7 +941,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(uint) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, UIntName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UIntName));
                 amount = UnreadBits / (sizeof(uint) * BitsPerByte);
             }
 
@@ -1108,7 +1108,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(long) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, LongName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, LongName));
                 amount = UnreadBits / (sizeof(long) * BitsPerByte);
             }
 
@@ -1127,7 +1127,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(ulong) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, ULongName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ULongName));
                 amount = UnreadBits / (sizeof(ulong) * BitsPerByte);
             }
 
@@ -1221,7 +1221,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(float) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, FloatName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, FloatName));
                 amount = UnreadBits / (sizeof(float) * BitsPerByte);
             }
 
@@ -1315,7 +1315,7 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(double) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(intoArray.Length, DoubleName));
+                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, DoubleName));
                 amount = UnreadBits / (sizeof(double) * BitsPerByte);
             }
 

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -248,6 +248,36 @@ namespace Riptide
 
         #region Add & Retrieve Data
         #region Bits
+        /// <summary>Moves the message's internal write position by the given <paramref name="amount"/> of bits, reserving them so they can be set at a later time.</summary>
+        /// <param name="amount">The number of bits to reserve.</param>
+        /// <returns>The message instance.</returns>
+        public Message ReserveBits(int amount)
+        {
+            if (UnwrittenBits < amount)
+                throw new InsufficientCapacityException(this, amount);
+
+            int bit = writeBit % BitsPerByte;
+            writeBit += amount;
+
+            // Reset the last byte that the reserved range touches, unless it's also the first one, in which case it may already contain data which we don't want to overwrite
+            if (bit != 0 && amount < BitsPerByte)
+                Bytes[writeBit / BitsPerByte] = 0;
+
+            return this;
+        }
+
+        /// <summary>Moves the message's internal read position by the given <paramref name="amount"/> of bits, skipping over them.</summary>
+        /// <param name="amount">The number of bits to skip.</param>
+        /// <returns>The message instance.</returns>
+        public Message SkipBits(int amount)
+        {
+            if (UnreadBits < amount)
+                RiptideLogger.Log(LogType.Error, $"Message only contains {UnreadBits} unread {Helper.CorrectForm(UnreadBits, "bit")}, which is not enough to skip {amount}!");
+
+            readBit += amount;
+            return this;
+        }
+
         /// <summary>Sets up to 8 bits at the specified position in the message.</summary>
         /// <param name="bitfield">The bitfield from which to write the bits into the message.</param>
         /// <param name="amount">The number of bits to set.</param>

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -1,4 +1,4 @@
-// This file is provided under The MIT License as part of RiptideNetworking.
+﻿// This file is provided under The MIT License as part of RiptideNetworking.
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
@@ -23,9 +23,13 @@ namespace Riptide
     /// <summary>Provides functionality for converting data to bytes and vice versa.</summary>
     public class Message
     {
+        /// <summary>The minimum number of bytes contained in an unreliable message.</summary>
         internal const int MinUnreliableBytes = 1;
+        /// <summary>The minimum number of bytes contained in a reliable message.</summary>
         internal const int MinReliableBytes = 3;
+        /// <summary>The minimum number of bytes contained in a notify message.</summary>
         internal const int MinNotifyBytes = 6;
+        /// <summary>The number of bits in a byte.</summary>
         internal const int BitsPerByte = 8;
         /// <summary>The header size for unreliable messages. Does not count the 2 bytes used for the message ID.</summary>
         /// <remarks>1 byte - header.</remarks>
@@ -57,6 +61,7 @@ namespace Riptide
                 TrimPool(); // When ActiveSocketCount is 0, this clears the pool
             }
         }
+        /// <summary>The maximum number of bits a message can contain.</summary>
         private static int maxBitCount = MaxSize * BitsPerByte;
 
         /// <summary>How many messages to add to the pool for each <see cref="Server"/> or <see cref="Client"/> instance that is started.</summary>
@@ -67,10 +72,15 @@ namespace Riptide
 
         /// <summary>The message's send mode.</summary>
         public MessageSendMode SendMode { get; private set; }
+        /// <summary>How many bits have been retrieved from the message.</summary>
         public int ReadBits => readBit;
+        /// <summary>How many unretrieved bits remain in the message.</summary>
         public int UnreadBits => writeBit - readBit;
+        /// <summary>How many bits have been added to the message.</summary>
         public int WrittenBits => writeBit;
+        /// <summary>How many more bits can be added to the message.</summary>
         public int UnwrittenBits => maxBitCount - writeBit;
+        /// <summary>How many of this message's bytes are in use. Rounds up to the next byte because only whole bytes can be sent.</summary>
         public int BytesInUse => writeBit / BitsPerByte + (writeBit % BitsPerByte == 0 ? 0 : 1);
         /// <summary>How many bytes have been retrieved from the message.</summary>
         [Obsolete("Use ReadBits instead.")] public int ReadLength => ReadBits / BitsPerByte + (ReadBits % BitsPerByte == 0 ? 0 : 1);
@@ -213,7 +223,7 @@ namespace Riptide
             return this;
         }
 
-        /// <summary>Sets the message's header byte to the given <paramref name="header"/> and determines the appropriate <see cref="MessageSendMode"/> and read/write positions.</summary>
+        /// <summary>Sets the message's header bits to the given <paramref name="header"/> and determines the appropriate <see cref="MessageSendMode"/> and read/write positions.</summary>
         /// <param name="header">The header to use for this message.</param>
         private void SetHeader(MessageHeader header)
         {
@@ -1357,7 +1367,7 @@ namespace Riptide
         /// <summary>The maximum number of elements an array can contain where the length still fits into two byte2.</summary>
         private const int TwoByteLengthThreshold = 0b_0111_1111_1111_1111;
 
-        /// <summary>Adds the length of an array to the message, using either 1 or 2 bytes depending on how large the array is. Does not support arrays with more than 32,767 elements.</summary>
+        /// <summary>Adds the length of an array to the message, using either 8 or 16 bits depending on how large the array is. Does not support arrays with more than 32,767 elements.</summary>
         /// <param name="length">The length of the array.</param>
         private void AddArrayLength(int length)
         {
@@ -1383,7 +1393,7 @@ namespace Riptide
             }
         }
 
-        /// <summary>Retrieves the length of an array from the message, using either 1 or 2 bytes depending on how large the array is.</summary>
+        /// <summary>Retrieves the length of an array from the message, using either 8 or 16 bits depending on how large the array is.</summary>
         /// <returns>The length of the array.</returns>
         private int GetArrayLength()
         {

--- a/RiptideNetworking/RiptideNetworking/Peer.cs
+++ b/RiptideNetworking/RiptideNetworking/Peer.cs
@@ -170,7 +170,7 @@ namespace Riptide
             else if (message.SendMode == MessageSendMode.Unreliable)
             {
                 if (e.Amount > Message.MinUnreliableBytes)
-                    Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1);
+                    Buffer.BlockCopy(e.DataBuffer, 1, message.Data, 1, e.Amount - 1);
 
                 messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));
                 e.FromConnection.Metrics.ReceivedUnreliable(e.Amount);
@@ -183,7 +183,7 @@ namespace Riptide
                 e.FromConnection.Metrics.ReceivedReliable(e.Amount);
                 if (e.FromConnection.ShouldHandle(Converter.UShortFromBits(e.DataBuffer, Message.HeaderBits)))
                 {
-                    Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1);
+                    Buffer.BlockCopy(e.DataBuffer, 1, message.Data, 1, e.Amount - 1);
                     messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));
                 }
                 else

--- a/RiptideNetworking/RiptideNetworking/Peer.cs
+++ b/RiptideNetworking/RiptideNetworking/Peer.cs
@@ -158,8 +158,7 @@ namespace Riptide
         /// <summary>Handles data received by the transport.</summary>
         protected void HandleData(object _, DataReceivedEventArgs e)
         {
-            MessageHeader header = (MessageHeader)e.DataBuffer[0];
-            Message message = Message.Create(header, e.Amount);
+            Message message = Message.Create().Init(e.DataBuffer[0], e.Amount, out MessageHeader header);
             
             if (header == MessageHeader.Notify)
             {
@@ -182,7 +181,7 @@ namespace Riptide
                     return;
 
                 e.FromConnection.Metrics.ReceivedReliable(e.Amount);
-                if (e.FromConnection.ShouldHandle(Converter.UShortFromBits(e.DataBuffer, 8)))
+                if (e.FromConnection.ShouldHandle(Converter.UShortFromBits(e.DataBuffer, Message.HeaderBits)))
                 {
                     Array.Copy(e.DataBuffer, 1, message.Bytes, 1, e.Amount - 1);
                     messagesToHandle.Enqueue(new MessageToHandle(message, header, e.FromConnection));

--- a/RiptideNetworking/RiptideNetworking/PendingMessage.cs
+++ b/RiptideNetworking/RiptideNetworking/PendingMessage.cs
@@ -50,9 +50,9 @@ namespace Riptide
             PendingMessage pendingMessage = RetrieveFromPool();
             pendingMessage.connection = connection;
 
-            message.SetBits(sequenceId, sizeof(ushort) * Message.BitsPerByte, Message.HeaderBits);
+            message.SetBits(sequenceId, sizeof(ushort) * Converter.BitsPerByte, Message.HeaderBits);
             pendingMessage.size = message.BytesInUse;
-            Array.Copy(message.Bytes, 0, pendingMessage.data, 0, pendingMessage.size);
+            Buffer.BlockCopy(message.Data, 0, pendingMessage.data, 0, pendingMessage.size);
 
             pendingMessage.sendAttempts = 0;
             pendingMessage.wasCleared = false;

--- a/RiptideNetworking/RiptideNetworking/PendingMessage.cs
+++ b/RiptideNetworking/RiptideNetworking/PendingMessage.cs
@@ -50,10 +50,9 @@ namespace Riptide
             PendingMessage pendingMessage = RetrieveFromPool();
             pendingMessage.connection = connection;
 
-            pendingMessage.data[0] = message.Bytes[0]; // Copy message header
-            Converter.UShortToBits(sequenceId, pendingMessage.data, 8); // Insert sequence ID
+            message.SetBits(sequenceId, sizeof(ushort) * Message.BitsPerByte, Message.HeaderBits);
             pendingMessage.size = message.BytesInUse;
-            Array.Copy(message.Bytes, 3, pendingMessage.data, 3, pendingMessage.size - 3); // Copy the rest of the message
+            Array.Copy(message.Bytes, 0, pendingMessage.data, 0, pendingMessage.size);
 
             pendingMessage.sendAttempts = 0;
             pendingMessage.wasCleared = false;
@@ -106,7 +105,7 @@ namespace Riptide
         {
             if (sendAttempts >= connection.MaxSendAttempts)
             {
-                RiptideLogger.Log(LogType.Info, connection.Peer.LogName, $"Could not guarantee delivery of a {(MessageHeader)data[0]} message after {sendAttempts} attempts! Disconnecting...");
+                RiptideLogger.Log(LogType.Info, connection.Peer.LogName, $"Could not guarantee delivery of a {(MessageHeader)(data[0] & Message.HeaderBitmask)} message after {sendAttempts} attempts! Disconnecting...");
                 connection.Peer.Disconnect(connection, DisconnectReason.PoorConnection);
                 return;
             }

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -266,7 +266,7 @@ namespace Riptide
                 Message message = Message.Create(MessageHeader.Reject);
                 message.AddByte((byte)reason);
                 if (reason == RejectReason.Custom)
-                    message.AddBytes(rejectMessage.GetBytes(rejectMessage.BytesInUse), false);
+                    message.AddMessage(rejectMessage);
 
                 for (int i = 0; i < 3; i++) // Send the rejection message a few times to increase the odds of it arriving
                     connection.Send(message, false);
@@ -516,7 +516,7 @@ namespace Riptide
             message.AddByte((byte)reason);
 
             if (reason == DisconnectReason.Kicked && disconnectMessage != null)
-                message.AddBytes(disconnectMessage.GetBytes(disconnectMessage.BytesInUse), false);
+                message.AddMessage(disconnectMessage);
 
             Send(message, client);
         }

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -220,7 +220,7 @@ namespace Riptide
         /// <param name="message">Data that should be sent to the client being rejected. Use <see cref="Message.Create()"/> to get an empty message instance.</param>
         public void Reject(Connection connection, Message message = null)
         {
-            if (message != null && message.ReadLength != 0)
+            if (message != null && message.ReadBits != 0)
                 RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when setting rejection data!");
 
             if (pendingConnections.Remove(connection))
@@ -266,7 +266,7 @@ namespace Riptide
                 Message message = Message.Create(MessageHeader.Reject);
                 message.AddByte((byte)reason);
                 if (reason == RejectReason.Custom)
-                    message.AddBytes(rejectMessage.GetBytes(rejectMessage.WrittenLength), false);
+                    message.AddBytes(rejectMessage.GetBytes(rejectMessage.BytesInUse), false);
 
                 for (int i = 0; i < 3; i++) // Send the rejection message a few times to increase the odds of it arriving
                     connection.Send(message, false);
@@ -336,7 +336,7 @@ namespace Riptide
                         OnClientConnected(connection);
                     break;
                 default:
-                    RiptideLogger.Log(LogType.Warning, LogName, $"Unexpected message header '{header}'! Discarding {message.WrittenLength} bytes received from {connection}.");
+                    RiptideLogger.Log(LogType.Warning, LogName, $"Unexpected message header '{header}'! Discarding {message.BytesInUse} bytes received from {connection}.");
                     break;
             }
 
@@ -398,7 +398,7 @@ namespace Riptide
         /// <param name="message">Data that should be sent to the client being disconnected. Use <see cref="Message.Create()"/> to get an empty message instance.</param>
         public void DisconnectClient(ushort id, Message message = null)
         {
-            if (message != null && message.ReadLength != 0)
+            if (message != null && message.ReadBits != 0)
                 RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when setting disconnection data!");
 
             if (clients.TryGetValue(id, out Connection client))
@@ -415,7 +415,7 @@ namespace Riptide
         /// <param name="message">Data that should be sent to the client being disconnected. Use <see cref="Message.Create()"/> to get an empty message instance.</param>
         public void DisconnectClient(Connection client, Message message = null)
         {
-            if (message != null && message.ReadLength != 0)
+            if (message != null && message.ReadBits != 0)
                 RiptideLogger.Log(LogType.Error, LogName, $"Use the parameterless 'Message.Create()' overload when setting disconnection data!");
 
             if (clients.ContainsKey(client.Id))
@@ -516,7 +516,7 @@ namespace Riptide
             message.AddByte((byte)reason);
 
             if (reason == DisconnectReason.Kicked && disconnectMessage != null)
-                message.AddBytes(disconnectMessage.GetBytes(disconnectMessage.WrittenLength), false);
+                message.AddBytes(disconnectMessage.GetBytes(disconnectMessage.BytesInUse), false);
 
             Send(message, client);
         }

--- a/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Tcp/TcpServer.cs
@@ -143,7 +143,7 @@ namespace Riptide.Transports.Tcp
         /// <inheritdoc/>
         protected internal override void OnDataReceived(int amount, TcpConnection fromConnection)
         {
-            if ((MessageHeader)ReceiveBuffer[0] == MessageHeader.Connect)
+            if ((MessageHeader)(ReceiveBuffer[0] & Message.HeaderBitmask) == MessageHeader.Connect)
             {
                 if (fromConnection.DidReceiveConnect)
                     return;

--- a/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
+++ b/RiptideNetworking/RiptideNetworking/Transports/Udp/UdpServer.cs
@@ -83,7 +83,7 @@ namespace Riptide.Transports.Udp
         /// <inheritdoc/>
         protected override void OnDataReceived(byte[] dataBuffer, int amount, IPEndPoint fromEndPoint)
         {
-            if ((MessageHeader)dataBuffer[0] == MessageHeader.Connect && !HandleConnectionAttempt(fromEndPoint))
+            if ((MessageHeader)(dataBuffer[0] & Message.HeaderBitmask) == MessageHeader.Connect && !HandleConnectionAttempt(fromEndPoint))
                 return;
 
             if (connections.TryGetValue(fromEndPoint, out Connection connection) && !connection.IsNotConnected)

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -1,4 +1,4 @@
-// This file is provided under The MIT License as part of RiptideNetworking.
+﻿// This file is provided under The MIT License as part of RiptideNetworking.
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
@@ -12,6 +12,11 @@ namespace Riptide.Utils
     /// <summary>Provides functionality for converting bits and bytes to various value types and vice versa.</summary>
     public class Converter
     {
+        /// <summary>The number of bits in a byte.</summary>
+        public const int BitsPerByte = 8;
+        /// <summary>The number of bits in a ulong.</summary>
+        public const int BitsPerULong = sizeof(ulong) * BitsPerByte;
+
         #region Bits
         /// <summary>Takes <paramref name="amount"/> bits from <paramref name="bitfield"/> and writes them into <paramref name="array"/>, starting at <paramref name="startBit"/>.</summary>
         /// <param name="bitfield">The bitfield from which to write the bits into the array.</param>
@@ -24,8 +29,8 @@ namespace Riptide.Utils
             byte mask = (byte)((1 << amount) - 1);
             bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
             int inverseMask = ~mask;
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
                 array[pos] = (byte)(bitfield | (array[pos] & inverseMask));
             else
@@ -41,8 +46,8 @@ namespace Riptide.Utils
             ushort mask = (ushort)((1 << amount) - 1);
             bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
             int inverseMask = ~mask;
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
@@ -64,8 +69,8 @@ namespace Riptide.Utils
             uint mask = (1u << (amount - 1) << 1) - 1; // Perform 2 shifts, doing it in 1 doesn't cause the value to wrap properly
             bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
             uint inverseMask = ~mask;
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
@@ -91,8 +96,8 @@ namespace Riptide.Utils
             ulong mask = (1ul << (amount - 1) << 1) - 1; // Perform 2 shifts, doing it in 1 doesn't cause the value to wrap properly
             bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
             ulong inverseMask = ~mask;
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
@@ -117,6 +122,24 @@ namespace Riptide.Utils
                 array[pos + 6] = (byte)((bitfield >> 40) | (array[pos + 6] & (inverseMask >> 40)));
                 array[pos + 7] = (byte)((bitfield >> 48) | (array[pos + 7] & (inverseMask >> 48)));
                 array[pos + 8] = (byte)((bitfield >> 56) | (array[pos + 8] & ~(mask >> (64 - bit)))); // This one can't use inverseMask because it would have incorrectly zeroed bits
+            }
+        }
+        /// <inheritdoc cref="SetBits(byte, int, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBits(ulong bitfield, int amount, ulong[] array, int startBit)
+        {
+            ulong mask = (1ul << (amount - 1) << 1) - 1; // Perform 2 shifts, doing it in 1 doesn't cause the value to wrap properly
+            bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            if (bit == 0)
+                array[pos] = bitfield | array[pos] & ~mask;
+            else if (bit + amount < BitsPerULong)
+                array[pos] |= bitfield << bit;
+            else
+            {
+                array[pos    ] = (bitfield << bit) | (array[pos] & ~(mask << bit));
+                array[pos + 1] = (bitfield >> (64 - bit)) | (array[pos + 1] & ~(mask >> (64 - bit)));
             }
         }
 
@@ -152,6 +175,34 @@ namespace Riptide.Utils
             bitfield = ULongFromBits(array, startBit);
             bitfield &= (1ul << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're reading
         }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, ulong[] array, int startBit, out byte bitfield)
+        {
+            bitfield = ByteFromBits(array, startBit);
+            bitfield &= (byte)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, ulong[] array, int startBit, out ushort bitfield)
+        {
+            bitfield = UShortFromBits(array, startBit);
+            bitfield &= (ushort)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, ulong[] array, int startBit, out uint bitfield)
+        {
+            bitfield = UIntFromBits(array, startBit);
+            bitfield &= (1u << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, ulong[] array, int startBit, out ulong bitfield)
+        {
+            bitfield = ULongFromBits(array, startBit);
+            bitfield &= (1ul << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're reading
+        }
         #endregion
 
         #region Byte/SByte
@@ -161,6 +212,9 @@ namespace Riptide.Utils
         /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SByteToBits(sbyte value, byte[] array, int startBit) => ByteToBits((byte)value, array, startBit);
+        /// <inheritdoc cref="SByteToBits(sbyte, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SByteToBits(sbyte value, ulong[] array, int startBit) => ByteToBits((byte)value, array, startBit);
         /// <summary>Converts <paramref name="value"/> to 8 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
         /// <param name="value">The <see cref="byte"/> to convert.</param>
         /// <param name="array">The array to write the bits into.</param>
@@ -168,16 +222,19 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ByteToBits(byte value, byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
                 array[pos] = value;
             else
             {
                 array[pos    ] |= (byte)(value << bit);
-                array[pos + 1] = (byte)(value >> (8 - bit));
+                array[pos + 1]  = (byte)(value >> (8 - bit));
             }
         }
+        /// <inheritdoc cref="ByteToBits(byte, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ByteToBits(byte value, ulong[] array, int startBit) => ToBits(value, BitsPerByte, array, startBit);
 
         /// <summary>Converts the 8 bits at <paramref name="startBit"/> in <paramref name="array"/> to an <see cref="sbyte"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -185,6 +242,9 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="sbyte"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte SByteFromBits(byte[] array, int startBit) => (sbyte)ByteFromBits(array, startBit);
+        /// <inheritdoc cref="SByteFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte SByteFromBits(ulong[] array, int startBit) => (sbyte)ByteFromBits(array, startBit);
         /// <summary>Converts the 8 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="byte"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
         /// <param name="startBit">The position in the array from which to read the bits.</param>
@@ -192,8 +252,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ByteFromBits(byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             byte value = array[pos];
             if (bit == 0)
                 return value;
@@ -201,6 +261,9 @@ namespace Riptide.Utils
             value >>= bit;
             return (byte)(value | (array[pos + 1] << (8 - bit)));
         }
+        /// <inheritdoc cref="ByteFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte ByteFromBits(ulong[] array, int startBit) => (byte)FromBits(BitsPerByte, array, startBit);
         #endregion
 
         #region Bool
@@ -211,13 +274,25 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void BoolToBit(bool value, byte[] array, int startBit)
         {
-            int pos = startBit / 8;
-            int bit = startBit % 8;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
                 array[pos] = 0;
 
             if (value)
                 array[pos] |= (byte)(1 << bit);
+        }
+        /// <inheritdoc cref="BoolToBit(bool, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void BoolToBit(bool value, ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            if (bit == 0)
+                array[pos] = 0;
+
+            if (value)
+                array[pos] |= 1ul << bit;
         }
 
         /// <summary>Converts the bit at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="bool"/>.</summary>
@@ -227,9 +302,17 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool BoolFromBit(byte[] array, int startBit)
         {
-            int pos = startBit / 8;
-            int bit = startBit % 8;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             return (array[pos] & (1 << bit)) != 0;
+        }
+        /// <inheritdoc cref="BoolFromBit(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool BoolFromBit(ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            return (array[pos] & (1ul << bit)) != 0;
         }
         #endregion
 
@@ -282,6 +365,9 @@ namespace Riptide.Utils
         /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ShortToBits(short value, byte[] array, int startBit) => UShortToBits((ushort)value, array, startBit);
+        /// <inheritdoc cref="ShortToBits(short, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ShortToBits(short value, ulong[] array, int startBit) => UShortToBits((ushort)value, array, startBit);
         /// <summary>Converts <paramref name="value"/> to 16 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
         /// <param name="value">The <see cref="ushort"/> to convert.</param>
         /// <param name="array">The array to write the bits into.</param>
@@ -289,8 +375,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UShortToBits(ushort value, byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos] = (byte)value;
@@ -304,6 +390,9 @@ namespace Riptide.Utils
                 array[pos + 2]  = (byte)(value >> 8);
             }
         }
+        /// <inheritdoc cref="UShortToBits(ushort, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void UShortToBits(ushort value, ulong[] array, int startBit) => ToBits(value, sizeof(ushort) * BitsPerByte, array, startBit);
 
         /// <summary>Converts the 16 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="short"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -311,6 +400,9 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="short"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ShortFromBits(byte[] array, int startBit) => (short)UShortFromBits(array, startBit);
+        /// <inheritdoc cref="ShortFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short ShortFromBits(ulong[] array, int startBit) => (short)UShortFromBits(array, startBit);
         /// <summary>Converts the 16 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="ushort"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
         /// <param name="startBit">The position in the array from which to read the bits.</param>
@@ -318,8 +410,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort UShortFromBits(byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             ushort value = (ushort)(array[pos] | (array[pos + 1] << 8));
             if (bit == 0)
                 return value;
@@ -327,6 +419,9 @@ namespace Riptide.Utils
             value >>= bit;
             return (ushort)(value | (array[pos + 2] << (16 - bit)));
         }
+        /// <inheritdoc cref="UShortFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort UShortFromBits(ulong[] array, int startBit) => (ushort)FromBits(sizeof(ushort) * BitsPerByte, array, startBit);
         #endregion
 
         #region Int/UInt
@@ -382,6 +477,9 @@ namespace Riptide.Utils
         /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IntToBits(int value, byte[] array, int startBit) => UIntToBits((uint)value, array, startBit);
+        /// <inheritdoc cref="IntToBits(int, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IntToBits(int value, ulong[] array, int startBit) => UIntToBits((uint)value, array, startBit);
         /// <summary>Converts <paramref name="value"/> to 32 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
         /// <param name="value">The <see cref="uint"/> to convert.</param>
         /// <param name="array">The array to write the bits into.</param>
@@ -389,8 +487,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UIntToBits(uint value, byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos    ] = (byte)value;
@@ -408,6 +506,9 @@ namespace Riptide.Utils
                 array[pos + 4] = (byte)(value >> 24);
             }
         }
+        /// <inheritdoc cref="UIntToBits(uint, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void UIntToBits(uint value, ulong[] array, int startBit) => ToBits(value, sizeof(uint) * BitsPerByte, array, startBit);
 
         /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to an <see cref="int"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -415,6 +516,9 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="int"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IntFromBits(byte[] array, int startBit) => (int)UIntFromBits(array, startBit);
+        /// <inheritdoc cref="IntFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IntFromBits(ulong[] array, int startBit) => (int)UIntFromBits(array, startBit);
         /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="uint"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
         /// <param name="startBit">The position in the array from which to read the bits.</param>
@@ -422,8 +526,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint UIntFromBits(byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             uint value = (uint)(array[pos] | (array[pos + 1] << 8) | (array[pos + 2] << 16) | (array[pos + 3] << 24));
             if (bit == 0)
                 return value;
@@ -431,6 +535,9 @@ namespace Riptide.Utils
             value >>= bit;
             return value | (uint)(array[pos + 4] << (32 - bit));
         }
+        /// <inheritdoc cref="UIntFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint UIntFromBits(ulong[] array, int startBit) => (uint)FromBits(sizeof(uint) * BitsPerByte, array, startBit);
         #endregion
 
         #region Long/ULong
@@ -499,6 +606,9 @@ namespace Riptide.Utils
         /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LongToBits(long value, byte[] array, int startBit) => ULongToBits((ulong)value, array, startBit);
+        /// <inheritdoc cref="LongToBits(long, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void LongToBits(long value, ulong[] array, int startBit) => ULongToBits((ulong)value, array, startBit);
         /// <summary>Converts <paramref name="value"/> to 64 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
         /// <param name="value">The <see cref="ulong"/> to convert.</param>
         /// <param name="array">The array to write the bits into.</param>
@@ -506,8 +616,8 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ULongToBits(ulong value, byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             if (bit == 0)
             {
                 array[pos    ] = (byte)value;
@@ -533,6 +643,20 @@ namespace Riptide.Utils
                 array[pos + 8] = (byte)(value >> 56);
             }
         }
+        /// <inheritdoc cref="ULongToBits(ulong, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ULongToBits(ulong value, ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            if (bit == 0)
+                array[pos] = value;
+            else
+            {
+                array[pos    ] |= value << bit;
+                array[pos + 1]  = value >> (BitsPerULong - bit);
+            }
+        }
 
         /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="long"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -540,6 +664,9 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="long"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LongFromBits(byte[] array, int startBit) => (long)ULongFromBits(array, startBit);
+        /// <inheritdoc cref="LongFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long LongFromBits(ulong[] array, int startBit) => (long)ULongFromBits(array, startBit);
         /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="ulong"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
         /// <param name="startBit">The position in the array from which to read the bits.</param>
@@ -547,14 +674,70 @@ namespace Riptide.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ULongFromBits(byte[] array, int startBit)
         {
-            int pos = startBit / Message.BitsPerByte;
-            int bit = startBit % Message.BitsPerByte;
+            int pos = startBit / BitsPerByte;
+            int bit = startBit % BitsPerByte;
             ulong value = BitConverter.ToUInt64(array, pos);
             if (bit == 0)
                 return value;
 
             value >>= bit;
             return value | ((ulong)array[pos + 8] << (64 - bit));
+        }
+        /// <inheritdoc cref="ULongFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ULongFromBits(ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            ulong value = array[pos];
+            if (bit == 0)
+                return value;
+
+            value >>= bit;
+            return value | (array[pos + 1] << (BitsPerULong - bit));
+        }
+
+        /// <summary>Converts <paramref name="value"/> to <paramref name="valueSize"/> bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.
+        /// Meant for values which fit into a <see cref="ulong"/>, not for <see cref="ulong"/>s themselves.</summary>
+        /// <param name="value">The value to convert.</param>
+        /// <param name="valueSize">The size in bits of the value being converted.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ToBits(ulong value, int valueSize, ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            if (bit == 0)
+                array[pos] = value;
+            else if (bit + valueSize < BitsPerULong)
+                array[pos] |= value << bit;
+            else
+            {
+                array[pos] |= value << bit;
+                array[pos + 1] = value >> (BitsPerULong - bit);
+            }
+        }
+        /// <summary>Converts the <paramref name="valueSize"/> bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="ulong"/>.
+        /// Meant for values which fit into a <see cref="ulong"/>, not for <see cref="ulong"/>s themselves.</summary>
+        /// <param name="valueSize">The size in bits of the value being converted.</param>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="ulong"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong FromBits(int valueSize, ulong[] array, int startBit)
+        {
+            int pos = startBit / BitsPerULong;
+            int bit = startBit % BitsPerULong;
+            ulong value = array[pos];
+            if (bit == 0)
+                return value;
+
+            value >>= bit;
+            if (bit + valueSize < BitsPerULong)
+                return value;
+
+            return value | (array[pos + 1] << (BitsPerULong - bit));
         }
         #endregion
 
@@ -603,6 +786,12 @@ namespace Riptide.Utils
         {
             UIntToBits(new FloatConverter { FloatValue = value }.UIntValue, array, startBit);
         }
+        /// <inheritdoc cref="FloatToBits(float, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FloatToBits(float value, ulong[] array, int startBit)
+        {
+            UIntToBits(new FloatConverter { FloatValue = value }.UIntValue, array, startBit);
+        }
 
         /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="float"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -610,6 +799,12 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="float"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FloatFromBits(byte[] array, int startBit)
+        {
+            return new FloatConverter { UIntValue = UIntFromBits(array, startBit) }.FloatValue;
+        }
+        /// <inheritdoc cref="FloatFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float FloatFromBits(ulong[] array, int startBit)
         {
             return new FloatConverter { UIntValue = UIntFromBits(array, startBit) }.FloatValue;
         }
@@ -667,6 +862,12 @@ namespace Riptide.Utils
         {
             ULongToBits(new DoubleConverter { DoubleValue = value }.ULongValue, array, startBit);
         }
+        /// <inheritdoc cref="DoubleToBits(double, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void DoubleToBits(double value, ulong[] array, int startBit)
+        {
+            ULongToBits(new DoubleConverter { DoubleValue = value }.ULongValue, array, startBit);
+        }
 
         /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="double"/>.</summary>
         /// <param name="array">The array to convert the bits from.</param>
@@ -674,6 +875,12 @@ namespace Riptide.Utils
         /// <returns>The converted <see cref="double"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double DoubleFromBits(byte[] array, int startBit)
+        {
+            return new DoubleConverter { ULongValue = ULongFromBits(array, startBit) }.DoubleValue;
+        }
+        /// <inheritdoc cref="DoubleFromBits(byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double DoubleFromBits(ulong[] array, int startBit)
         {
             return new DoubleConverter { ULongValue = ULongFromBits(array, startBit) }.DoubleValue;
         }

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -1,4 +1,4 @@
-﻿// This file is provided under The MIT License as part of RiptideNetworking.
+// This file is provided under The MIT License as part of RiptideNetworking.
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
@@ -12,6 +12,148 @@ namespace Riptide.Utils
     /// <summary>Provides functionality for converting bits and bytes to various value types and vice versa.</summary>
     public class Converter
     {
+        #region Bits
+        /// <summary>Takes <paramref name="amount"/> bits from <paramref name="bitfield"/> and writes them into <paramref name="array"/>, starting at <paramref name="startBit"/>.</summary>
+        /// <param name="bitfield">The bitfield from which to write the bits into the array.</param>
+        /// <param name="amount">The number of bits to write.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The bit position in the array at which to start writing.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBits(byte bitfield, int amount, byte[] array, int startBit)
+        {
+            byte mask = (byte)((1 << amount) - 1);
+            bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
+            int inverseMask = ~mask;
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+                array[pos] = (byte)(bitfield | (array[pos] & inverseMask));
+            else
+            {
+                array[pos    ] = (byte)((bitfield << bit) | (array[pos] & ~(mask << bit)));
+                array[pos + 1] = (byte)((bitfield >> (8 - bit)) | (array[pos + 1] & (inverseMask >> (8 - bit))));
+            }
+        }
+        /// <inheritdoc cref="SetBits(byte, int, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBits(ushort bitfield, int amount, byte[] array, int startBit)
+        {
+            ushort mask = (ushort)((1 << amount) - 1);
+            bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
+            int inverseMask = ~mask;
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
+                array[pos + 1] = (byte)((bitfield >> 8) | (array[pos + 1] & (inverseMask >> 8)));
+            }
+            else
+            {
+                array[pos    ] = (byte)((bitfield << bit) | (array[pos] & ~(mask << bit)));
+                bitfield >>= 8 - bit;
+                inverseMask >>= 8 - bit;
+                array[pos + 1] = (byte)(bitfield | (array[pos + 1] & inverseMask));
+                array[pos + 2] = (byte)((bitfield >> 8) | (array[pos + 2] & (inverseMask >> 8)));
+            }
+        }
+        /// <inheritdoc cref="SetBits(byte, int, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBits(uint bitfield, int amount, byte[] array, int startBit)
+        {
+            uint mask = (1u << (amount - 1) << 1) - 1; // Perform 2 shifts, doing it in 1 doesn't cause the value to wrap properly
+            bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
+            uint inverseMask = ~mask;
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
+                array[pos + 1] = (byte)((bitfield >>  8) | (array[pos + 1] & (inverseMask >>  8)));
+                array[pos + 2] = (byte)((bitfield >> 16) | (array[pos + 2] & (inverseMask >> 16)));
+                array[pos + 3] = (byte)((bitfield >> 24) | (array[pos + 3] & (inverseMask >> 24)));
+            }
+            else
+            {
+                array[pos    ] = (byte)((bitfield << bit) | (array[pos] & ~(mask << bit)));
+                bitfield >>= 8 - bit;
+                inverseMask >>= 8 - bit;
+                array[pos + 1] = (byte)(bitfield | (array[pos + 1] & inverseMask));
+                array[pos + 2] = (byte)((bitfield >>  8) | (array[pos + 2] & (inverseMask >>  8)));
+                array[pos + 3] = (byte)((bitfield >> 16) | (array[pos + 3] & (inverseMask >> 16)));
+                array[pos + 4] = (byte)((bitfield >> 24) | (array[pos + 4] & (inverseMask >> 24)));
+            }
+        }
+        /// <inheritdoc cref="SetBits(byte, int, byte[], int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetBits(ulong bitfield, int amount, byte[] array, int startBit)
+        {
+            ulong mask = (1ul << (amount - 1) << 1) - 1; // Perform 2 shifts, doing it in 1 doesn't cause the value to wrap properly
+            bitfield &= mask; // Discard any bits that are set beyond the ones we're setting
+            ulong inverseMask = ~mask;
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos    ] = (byte)(bitfield | (array[pos] & inverseMask));
+                array[pos + 1] = (byte)((bitfield >>  8) | (array[pos + 1] & (inverseMask >>  8)));
+                array[pos + 2] = (byte)((bitfield >> 16) | (array[pos + 2] & (inverseMask >> 16)));
+                array[pos + 3] = (byte)((bitfield >> 24) | (array[pos + 3] & (inverseMask >> 24)));
+                array[pos + 4] = (byte)((bitfield >> 32) | (array[pos + 4] & (inverseMask >> 32)));
+                array[pos + 5] = (byte)((bitfield >> 40) | (array[pos + 5] & (inverseMask >> 40)));
+                array[pos + 6] = (byte)((bitfield >> 48) | (array[pos + 6] & (inverseMask >> 48)));
+                array[pos + 7] = (byte)((bitfield >> 56) | (array[pos + 7] & (inverseMask >> 56)));
+            }
+            else
+            {
+                array[pos    ] = (byte)((bitfield << bit) | (array[pos] & ~(mask << bit)));
+                bitfield >>= 8 - bit;
+                inverseMask >>= 8 - bit;
+                array[pos + 1] = (byte)(bitfield | (array[pos + 1] & inverseMask));
+                array[pos + 2] = (byte)((bitfield >>  8) | (array[pos + 2] & (inverseMask >>  8)));
+                array[pos + 3] = (byte)((bitfield >> 16) | (array[pos + 3] & (inverseMask >> 16)));
+                array[pos + 4] = (byte)((bitfield >> 24) | (array[pos + 4] & (inverseMask >> 24)));
+                array[pos + 5] = (byte)((bitfield >> 32) | (array[pos + 5] & (inverseMask >> 32)));
+                array[pos + 6] = (byte)((bitfield >> 40) | (array[pos + 6] & (inverseMask >> 40)));
+                array[pos + 7] = (byte)((bitfield >> 48) | (array[pos + 7] & (inverseMask >> 48)));
+                array[pos + 8] = (byte)((bitfield >> 56) | (array[pos + 8] & (inverseMask >> 56)));
+            }
+        }
+
+        /// <summary>Starting at <paramref name="startBit"/>, reads <paramref name="amount"/> bits from <paramref name="array"/> into <paramref name="bitfield"/>.</summary>
+        /// <param name="amount">The number of bits to read.</param>
+        /// <param name="array">The array to read the bits from.</param>
+        /// <param name="startBit">The bit position in the array at which to start reading.</param>
+        /// <param name="bitfield">The bitfield into which to write the bits from the array.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, byte[] array, int startBit, out byte bitfield)
+        {
+            bitfield = ByteFromBits(array, startBit);
+            bitfield &= (byte)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, byte[] array, int startBit, out ushort bitfield)
+        {
+            bitfield = UShortFromBits(array, startBit);
+            bitfield &= (ushort)((1 << amount) - 1); // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, byte[] array, int startBit, out uint bitfield)
+        {
+            bitfield = UIntFromBits(array, startBit);
+            bitfield &= (1u << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're reading
+        }
+        /// <inheritdoc cref="GetBits(int, byte[], int, out byte)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void GetBits(int amount, byte[] array, int startBit, out ulong bitfield)
+        {
+            bitfield = ULongFromBits(array, startBit);
+            bitfield &= (1ul << (amount - 1) << 1) - 1; // Discard any bits that are set beyond the ones we're reading
+        }
+        #endregion
+
         #region Byte/SByte
         /// <summary>Converts <paramref name="value"/> to 8 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
         /// <param name="value">The <see cref="sbyte"/> to convert.</param>

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -12,22 +12,68 @@ namespace Riptide.Utils
     /// <summary>Provides functionality for converting bytes to various value types and vice versa.</summary>
     public class Converter
     {
+        #region Byte/SByte
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SByteToBits(sbyte value, byte[] array, int startBit) => ByteToBits((byte)value, array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ByteToBits(byte value, byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+                array[pos] = value;
+            else
+            {
+                array[pos    ] |= (byte)(value << bit);
+                array[pos + 1] = (byte)(value >> (8 - bit));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static sbyte SByteFromBits(byte[] array, int startBit) => (sbyte)ByteFromBits(array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte ByteFromBits(byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            byte value = array[pos];
+            if (bit == 0)
+                return value;
+
+            value >>= bit;
+            return (byte)(value | (array[pos + 1] << (8 - bit)));
+        }
+        #endregion
+
+        #region Bool
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void BoolToBit(bool value, byte[] array, int startBit)
+        {
+            int pos = startBit / 8;
+            int bit = startBit % 8;
+            if (bit == 0)
+                array[pos] = 0;
+
+            if (value)
+                array[pos] |= (byte)(1 << bit);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool BoolFromBit(byte[] array, int startBit)
+        {
+            int pos = startBit / 8;
+            int bit = startBit % 8;
+            return (array[pos] & (1 << bit)) != 0;
+        }
+        #endregion
+
         #region Short/UShort
         /// <summary>Converts a given <see cref="short"/> to bytes and writes them into the given array.</summary>
         /// <param name="value">The <see cref="short"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void FromShort(short value, byte[] array, int startIndex)
-        {
-#if BIG_ENDIAN
-            array[startIndex + 1] = (byte)value;
-            array[startIndex    ] = (byte)(value >> 8);
-#else
-            array[startIndex    ] = (byte)value;
-            array[startIndex + 1] = (byte)(value >> 8);
-#endif
-        }
+        public static void FromShort(short value, byte[] array, int startIndex) => FromUShort((ushort)value, array, startIndex);
         /// <summary>Converts a given <see cref="ushort"/> to bytes and writes them into the given array.</summary>
         /// <param name="value">The <see cref="ushort"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
@@ -49,14 +95,7 @@ namespace Riptide.Utils
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="short"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ToShort(byte[] array, int startIndex)
-        {
-#if BIG_ENDIAN
-            return (short)(array[startIndex + 1] | (array[startIndex    ] << 8));
-#else
-            return (short)(array[startIndex    ] | (array[startIndex + 1] << 8));
-#endif
-        }
+        public static short ToShort(byte[] array, int startIndex) => (short)ToUShort(array, startIndex);
         /// <summary>Converts the 2 bytes in the array at <paramref name="startIndex"/> to a <see cref="ushort"/>.</summary>
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
@@ -70,6 +109,41 @@ namespace Riptide.Utils
             return (ushort)(array[startIndex    ] | (array[startIndex + 1] << 8));
 #endif
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ShortToBits(short value, byte[] array, int startBit) => UShortToBits((ushort)value, array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void UShortToBits(ushort value, byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos] = (byte)value;
+                array[pos + 1] = (byte)(value >> 8);
+            }
+            else
+            {
+                array[pos    ] |= (byte)(value << bit);
+                array[pos + 1]  = (byte)(value >> (8 - bit));
+                array[pos + 2]  = (byte)(value >> (16 - bit));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short ShortFromBits(byte[] array, int startBit) => (short)UShortFromBits(array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort UShortFromBits(byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            ushort value = (ushort)(array[pos] | (array[pos + 1] << 8));
+            if (bit == 0)
+                return value;
+            
+            value >>= bit;
+            return (ushort)(value | (array[pos + 2] << (16 - bit)));
+        }
         #endregion
 
         #region Int/UInt
@@ -78,20 +152,7 @@ namespace Riptide.Utils
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void FromInt(int value, byte[] array, int startIndex)
-        {
-#if BIG_ENDIAN
-            array[startIndex + 3] = (byte)value;
-            array[startIndex + 2] = (byte)(value >> 8);
-            array[startIndex + 1] = (byte)(value >> 16);
-            array[startIndex    ] = (byte)(value >> 24);
-#else
-            array[startIndex    ] = (byte)value;
-            array[startIndex + 1] = (byte)(value >> 8);
-            array[startIndex + 2] = (byte)(value >> 16);
-            array[startIndex + 3] = (byte)(value >> 24);
-#endif
-        }
+        public static void FromInt(int value, byte[] array, int startIndex) => FromUInt((uint)value, array, startIndex);
         /// <summary>Converts a given <see cref="uint"/> to bytes and writes them into the given array.</summary>
         /// <param name="value">The <see cref="uint"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
@@ -117,14 +178,7 @@ namespace Riptide.Utils
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
         /// <returns>The converted <see cref="int"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ToInt(byte[] array, int startIndex)
-        {
-#if BIG_ENDIAN
-            return array[startIndex + 3] | (array[startIndex + 2] << 8) | (array[startIndex + 1] << 16) | (array[startIndex    ] << 24);
-#else
-            return array[startIndex    ] | (array[startIndex + 1] << 8) | (array[startIndex + 2] << 16) | (array[startIndex + 3] << 24);
-#endif
-        }
+        public static int ToInt(byte[] array, int startIndex) => (int)ToUInt(array, startIndex);
         /// <summary>Converts the 4 bytes in the array at <paramref name="startIndex"/> to a <see cref="uint"/>.</summary>
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
@@ -138,6 +192,45 @@ namespace Riptide.Utils
             return (uint)(array[startIndex    ] | (array[startIndex + 1] << 8) | (array[startIndex + 2] << 16) | (array[startIndex + 3] << 24));
 #endif
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void IntToBits(int value, byte[] array, int startBit) => UIntToBits((uint)value, array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void UIntToBits(uint value, byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos    ] = (byte)value;
+                array[pos + 1] = (byte)(value >> 8);
+                array[pos + 2] = (byte)(value >> 16);
+                array[pos + 3] = (byte)(value >> 24);
+            }
+            else
+            {
+                array[pos    ] |= (byte)(value << bit);
+                array[pos + 1] = (byte)(value >> (8 - bit));
+                array[pos + 2] = (byte)(value >> (16 - bit));
+                array[pos + 3] = (byte)(value >> (24 - bit));
+                array[pos + 4] = (byte)(value >> (32 - bit));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IntFromBits(byte[] array, int startBit) => (int)UIntFromBits(array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint UIntFromBits(byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            uint value = (uint)(array[pos] | (array[pos + 1] << 8) | (array[pos + 2] << 16) | (array[pos + 3] << 24));
+            if (bit == 0)
+                return value;
+            
+            value >>= bit;
+            return value | (uint)(array[pos + 4] << (32 - bit));
+        }
         #endregion
 
         #region Long/ULong
@@ -146,28 +239,7 @@ namespace Riptide.Utils
         /// <param name="array">The array to write the bytes into.</param>
         /// <param name="startIndex">The position in the array at which to write the bytes.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void FromLong(long value, byte[] array, int startIndex)
-        {
-#if BIG_ENDIAN
-            array[startIndex + 7] = (byte)value;
-            array[startIndex + 6] = (byte)(value >> 8);
-            array[startIndex + 5] = (byte)(value >> 16);
-            array[startIndex + 4] = (byte)(value >> 24);
-            array[startIndex + 3] = (byte)(value >> 32);
-            array[startIndex + 2] = (byte)(value >> 40);
-            array[startIndex + 1] = (byte)(value >> 48);
-            array[startIndex    ] = (byte)(value >> 56);
-#else
-            array[startIndex    ] = (byte)value;
-            array[startIndex + 1] = (byte)(value >> 8);
-            array[startIndex + 2] = (byte)(value >> 16);
-            array[startIndex + 3] = (byte)(value >> 24);
-            array[startIndex + 4] = (byte)(value >> 32);
-            array[startIndex + 5] = (byte)(value >> 40);
-            array[startIndex + 6] = (byte)(value >> 48);
-            array[startIndex + 7] = (byte)(value >> 56);
-#endif
-        }
+        public static void FromLong(long value, byte[] array, int startIndex) => FromULong((ulong)value, array, startIndex);
         /// <summary>Converts a given <see cref="ulong"/> to bytes and writes them into the given array.</summary>
         /// <param name="value">The <see cref="ulong"/> to convert.</param>
         /// <param name="array">The array to write the bytes into.</param>
@@ -208,7 +280,6 @@ namespace Riptide.Utils
 #endif
             return BitConverter.ToInt64(array, startIndex);
         }
-
         /// <summary>Converts the 8 bytes in the array at <paramref name="startIndex"/> to a <see cref="ulong"/>.</summary>
         /// <param name="array">The array to read the bytes from.</param>
         /// <param name="startIndex">The position in the array at which to read the bytes.</param>
@@ -219,7 +290,54 @@ namespace Riptide.Utils
 #if BIG_ENDIAN
             Array.Reverse(array, startIndex, ulongLength);
 #endif
-            return (ulong)BitConverter.ToInt64(array, startIndex);
+            return BitConverter.ToUInt64(array, startIndex);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void LongToBits(long value, byte[] array, int startBit) => ULongToBits((ulong)value, array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ULongToBits(ulong value, byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            if (bit == 0)
+            {
+                array[pos    ] = (byte)value;
+                array[pos + 1] = (byte)(value >> 8);
+                array[pos + 2] = (byte)(value >> 16);
+                array[pos + 3] = (byte)(value >> 24);
+                array[pos + 4] = (byte)(value >> 32);
+                array[pos + 5] = (byte)(value >> 40);
+                array[pos + 6] = (byte)(value >> 48);
+                array[pos + 7] = (byte)(value >> 56);
+            }
+            else
+            {
+                array[pos    ] |= (byte)(value << bit);
+                array[pos + 1] = (byte)(value >> (8 - bit));
+                array[pos + 2] = (byte)(value >> (16 - bit));
+                array[pos + 3] = (byte)(value >> (24 - bit));
+                array[pos + 4] = (byte)(value >> (32 - bit));
+                array[pos + 5] = (byte)(value >> (40 - bit));
+                array[pos + 6] = (byte)(value >> (48 - bit));
+                array[pos + 7] = (byte)(value >> (56 - bit));
+                array[pos + 8] = (byte)(value >> (64 - bit));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long LongFromBits(byte[] array, int startBit) => (long)ULongFromBits(array, startBit);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ULongFromBits(byte[] array, int startBit)
+        {
+            int pos = startBit / Message.BitsPerByte;
+            int bit = startBit % Message.BitsPerByte;
+            ulong value = BitConverter.ToUInt64(array, pos);
+            if (bit == 0)
+                return value;
+
+            value >>= bit;
+            return value | ((ulong)array[pos + 8] << (64 - bit));
         }
         #endregion
 
@@ -257,6 +375,18 @@ namespace Riptide.Utils
 #else
             return new FloatConverter { Byte0 = array[startIndex], Byte1 = array[startIndex + 1], Byte2 = array[startIndex + 2], Byte3 = array[startIndex + 3] }.FloatValue;
 #endif
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FloatToBits(float value, byte[] array, int startBit)
+        {
+            UIntToBits(new FloatConverter { FloatValue = value }.UIntValue, array, startBit);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float FloatFromBits(byte[] array, int startBit)
+        {
+            return new FloatConverter { UIntValue = UIntFromBits(array, startBit) }.FloatValue;
         }
         #endregion
 
@@ -302,6 +432,18 @@ namespace Riptide.Utils
 #endif
             return BitConverter.ToDouble(array, startIndex);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void DoubleToBits(double value, byte[] array, int startBit)
+        {
+            ULongToBits(new DoubleConverter { DoubleValue = value }.ULongValue, array, startBit);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double DoubleFromBits(byte[] array, int startBit)
+        {
+            return new DoubleConverter { ULongValue = ULongFromBits(array, startBit) }.DoubleValue;
+        }
         #endregion
     }
 
@@ -314,6 +456,8 @@ namespace Riptide.Utils
         [FieldOffset(3)] public byte Byte3;
 
         [FieldOffset(0)] public float FloatValue;
+
+        [FieldOffset(0)] public uint UIntValue;
     }
 
     [StructLayout(LayoutKind.Explicit)]
@@ -329,5 +473,7 @@ namespace Riptide.Utils
         [FieldOffset(7)] public byte Byte7;
 
         [FieldOffset(0)] public double DoubleValue;
+
+        [FieldOffset(0)] public ulong ULongValue;
     }
 }

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -17,6 +17,42 @@ namespace Riptide.Utils
         /// <summary>The number of bits in a ulong.</summary>
         public const int BitsPerULong = sizeof(ulong) * BitsPerByte;
 
+        #region Zig Zag Encoding
+        /// <summary>Zig zag encodes <paramref name="value"/>.</summary>
+        /// <param name="value">The value to encode.</param>
+        /// <returns>The zig zag-encoded value.</returns>
+        /// <remarks>Zig zag encoding allows small negative numbers to be represented as small positive numbers. All positive numbers are doubled and become even numbers,
+        /// while all negative numbers become positive odd numbers. In contrast, simply casting a negative value to its unsigned counterpart would result in a large positive
+        /// number which uses the high bit, rendering compression via <see cref="Message.AddVarULong(ulong)"/> and <see cref="Message.GetVarULong"/> ineffective.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ZigZagEncode(int value)
+        {
+            return (value >> 31) ^ (value << 1);
+        }
+        /// <inheritdoc cref="ZigZagEncode(int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ZigZagEncode(long value)
+        {
+            return (value >> 63) ^ (value << 1);
+        }
+
+        /// <summary>Zig zag decodes <paramref name="value"/>.</summary>
+        /// <param name="value">The value to decode.</param>
+        /// <returns>The zig zag-decoded value.</returns>
+        /// <inheritdoc cref="ZigZagEncode(int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ZigZagDecode(int value)
+        {
+            return (value >> 1) ^ -(value & 1);
+        }
+        /// <inheritdoc cref="ZigZagDecode(int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ZigZagDecode(long value)
+        {
+            return (value >> 1) ^ -(value & 1);
+        }
+        #endregion
+
         #region Bits
         /// <summary>Takes <paramref name="amount"/> bits from <paramref name="bitfield"/> and writes them into <paramref name="array"/>, starting at <paramref name="startBit"/>.</summary>
         /// <param name="bitfield">The bitfield from which to write the bits into the array.</param>

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -9,12 +9,20 @@ using System.Runtime.InteropServices;
 
 namespace Riptide.Utils
 {
-    /// <summary>Provides functionality for converting bytes to various value types and vice versa.</summary>
+    /// <summary>Provides functionality for converting bits and bytes to various value types and vice versa.</summary>
     public class Converter
     {
         #region Byte/SByte
+        /// <summary>Converts <paramref name="value"/> to 8 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="sbyte"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void SByteToBits(sbyte value, byte[] array, int startBit) => ByteToBits((byte)value, array, startBit);
+        /// <summary>Converts <paramref name="value"/> to 8 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="byte"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ByteToBits(byte value, byte[] array, int startBit)
         {
@@ -29,8 +37,16 @@ namespace Riptide.Utils
             }
         }
 
+        /// <summary>Converts the 8 bits at <paramref name="startBit"/> in <paramref name="array"/> to an <see cref="sbyte"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="sbyte"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte SByteFromBits(byte[] array, int startBit) => (sbyte)ByteFromBits(array, startBit);
+        /// <summary>Converts the 8 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="byte"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="byte"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte ByteFromBits(byte[] array, int startBit)
         {
@@ -46,6 +62,10 @@ namespace Riptide.Utils
         #endregion
 
         #region Bool
+        /// <summary>Converts <paramref name="value"/> to a bit and writes it into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="bool"/> to convert.</param>
+        /// <param name="array">The array to write the bit into.</param>
+        /// <param name="startBit">The position in the array at which to write the bit.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void BoolToBit(bool value, byte[] array, int startBit)
         {
@@ -58,6 +78,10 @@ namespace Riptide.Utils
                 array[pos] |= (byte)(1 << bit);
         }
 
+        /// <summary>Converts the bit at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="bool"/>.</summary>
+        /// <param name="array">The array to convert the bit from.</param>
+        /// <param name="startBit">The position in the array from which to read the bit.</param>
+        /// <returns>The converted <see cref="bool"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool BoolFromBit(byte[] array, int startBit)
         {
@@ -110,8 +134,16 @@ namespace Riptide.Utils
 #endif
         }
 
+        /// <summary>Converts <paramref name="value"/> to 16 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="short"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ShortToBits(short value, byte[] array, int startBit) => UShortToBits((ushort)value, array, startBit);
+        /// <summary>Converts <paramref name="value"/> to 16 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="ushort"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UShortToBits(ushort value, byte[] array, int startBit)
         {
@@ -130,8 +162,16 @@ namespace Riptide.Utils
             }
         }
 
+        /// <summary>Converts the 16 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="short"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="short"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ShortFromBits(byte[] array, int startBit) => (short)UShortFromBits(array, startBit);
+        /// <summary>Converts the 16 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="ushort"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="ushort"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ushort UShortFromBits(byte[] array, int startBit)
         {
@@ -193,8 +233,16 @@ namespace Riptide.Utils
 #endif
         }
 
+        /// <summary>Converts <paramref name="value"/> to 32 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="int"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void IntToBits(int value, byte[] array, int startBit) => UIntToBits((uint)value, array, startBit);
+        /// <summary>Converts <paramref name="value"/> to 32 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="uint"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void UIntToBits(uint value, byte[] array, int startBit)
         {
@@ -217,8 +265,16 @@ namespace Riptide.Utils
             }
         }
 
+        /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to an <see cref="int"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="int"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IntFromBits(byte[] array, int startBit) => (int)UIntFromBits(array, startBit);
+        /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="uint"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="uint"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint UIntFromBits(byte[] array, int startBit)
         {
@@ -293,8 +349,16 @@ namespace Riptide.Utils
             return BitConverter.ToUInt64(array, startIndex);
         }
 
+        /// <summary>Converts <paramref name="value"/> to 64 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="long"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LongToBits(long value, byte[] array, int startBit) => ULongToBits((ulong)value, array, startBit);
+        /// <summary>Converts <paramref name="value"/> to 64 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="ulong"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void ULongToBits(ulong value, byte[] array, int startBit)
         {
@@ -325,8 +389,16 @@ namespace Riptide.Utils
             }
         }
 
+        /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="long"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="long"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long LongFromBits(byte[] array, int startBit) => (long)ULongFromBits(array, startBit);
+        /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="ulong"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="ulong"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong ULongFromBits(byte[] array, int startBit)
         {
@@ -376,13 +448,21 @@ namespace Riptide.Utils
             return new FloatConverter { Byte0 = array[startIndex], Byte1 = array[startIndex + 1], Byte2 = array[startIndex + 2], Byte3 = array[startIndex + 3] }.FloatValue;
 #endif
         }
-        
+
+        /// <summary>Converts <paramref name="value"/> to 32 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="float"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void FloatToBits(float value, byte[] array, int startBit)
         {
             UIntToBits(new FloatConverter { FloatValue = value }.UIntValue, array, startBit);
         }
 
+        /// <summary>Converts the 32 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="float"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="float"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float FloatFromBits(byte[] array, int startBit)
         {
@@ -433,12 +513,20 @@ namespace Riptide.Utils
             return BitConverter.ToDouble(array, startIndex);
         }
 
+        /// <summary>Converts <paramref name="value"/> to 64 bits and writes them into <paramref name="array"/> at <paramref name="startBit"/>.</summary>
+        /// <param name="value">The <see cref="double"/> to convert.</param>
+        /// <param name="array">The array to write the bits into.</param>
+        /// <param name="startBit">The position in the array at which to write the bits.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void DoubleToBits(double value, byte[] array, int startBit)
         {
             ULongToBits(new DoubleConverter { DoubleValue = value }.ULongValue, array, startBit);
         }
 
+        /// <summary>Converts the 64 bits at <paramref name="startBit"/> in <paramref name="array"/> to a <see cref="double"/>.</summary>
+        /// <param name="array">The array to convert the bits from.</param>
+        /// <param name="startBit">The position in the array from which to read the bits.</param>
+        /// <returns>The converted <see cref="double"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double DoubleFromBits(byte[] array, int startBit)
         {

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -157,8 +157,9 @@ namespace Riptide.Utils
             else
             {
                 array[pos    ] |= (byte)(value << bit);
-                array[pos + 1]  = (byte)(value >> (8 - bit));
-                array[pos + 2]  = (byte)(value >> (16 - bit));
+                value >>= 8 - bit;
+                array[pos + 1]  = (byte)value;
+                array[pos + 2]  = (byte)(value >> 8);
             }
         }
 
@@ -258,10 +259,11 @@ namespace Riptide.Utils
             else
             {
                 array[pos    ] |= (byte)(value << bit);
-                array[pos + 1] = (byte)(value >> (8 - bit));
-                array[pos + 2] = (byte)(value >> (16 - bit));
-                array[pos + 3] = (byte)(value >> (24 - bit));
-                array[pos + 4] = (byte)(value >> (32 - bit));
+                value >>= 8 - bit;
+                array[pos + 1] = (byte)value;
+                array[pos + 2] = (byte)(value >> 8);
+                array[pos + 3] = (byte)(value >> 16);
+                array[pos + 4] = (byte)(value >> 24);
             }
         }
 
@@ -378,14 +380,15 @@ namespace Riptide.Utils
             else
             {
                 array[pos    ] |= (byte)(value << bit);
-                array[pos + 1] = (byte)(value >> (8 - bit));
-                array[pos + 2] = (byte)(value >> (16 - bit));
-                array[pos + 3] = (byte)(value >> (24 - bit));
-                array[pos + 4] = (byte)(value >> (32 - bit));
-                array[pos + 5] = (byte)(value >> (40 - bit));
-                array[pos + 6] = (byte)(value >> (48 - bit));
-                array[pos + 7] = (byte)(value >> (56 - bit));
-                array[pos + 8] = (byte)(value >> (64 - bit));
+                value >>= 8 - bit;
+                array[pos + 1] = (byte)value;
+                array[pos + 2] = (byte)(value >> 8);
+                array[pos + 3] = (byte)(value >> 16);
+                array[pos + 4] = (byte)(value >> 24);
+                array[pos + 5] = (byte)(value >> 32);
+                array[pos + 6] = (byte)(value >> 40);
+                array[pos + 7] = (byte)(value >> 48);
+                array[pos + 8] = (byte)(value >> 56);
             }
         }
 

--- a/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/Converter.cs
@@ -81,7 +81,7 @@ namespace Riptide.Utils
                 array[pos + 1] = (byte)(bitfield | (array[pos + 1] & inverseMask));
                 array[pos + 2] = (byte)((bitfield >>  8) | (array[pos + 2] & (inverseMask >>  8)));
                 array[pos + 3] = (byte)((bitfield >> 16) | (array[pos + 3] & (inverseMask >> 16)));
-                array[pos + 4] = (byte)((bitfield >> 24) | (array[pos + 4] & (inverseMask >> 24)));
+                array[pos + 4] = (byte)((bitfield >> 24) | (array[pos + 4] & ~(mask >> (32 - bit)))); // This one can't use inverseMask because it would have incorrectly zeroed bits
             }
         }
         /// <inheritdoc cref="SetBits(byte, int, byte[], int)"/>
@@ -116,7 +116,7 @@ namespace Riptide.Utils
                 array[pos + 5] = (byte)((bitfield >> 32) | (array[pos + 5] & (inverseMask >> 32)));
                 array[pos + 6] = (byte)((bitfield >> 40) | (array[pos + 6] & (inverseMask >> 40)));
                 array[pos + 7] = (byte)((bitfield >> 48) | (array[pos + 7] & (inverseMask >> 48)));
-                array[pos + 8] = (byte)((bitfield >> 56) | (array[pos + 8] & (inverseMask >> 56)));
+                array[pos + 8] = (byte)((bitfield >> 56) | (array[pos + 8] & ~(mask >> (64 - bit)))); // This one can't use inverseMask because it would have incorrectly zeroed bits
             }
         }
 


### PR DESCRIPTION
This PR overhauls the `Message` class to operate on the bit level and adds support for adding & retrieving specific numbers of bits. This makes it much easier to reduce bandwidth required by no longer forcing data to be byte-aligned.

For example, `AddBool` previously used an entire byte to add a bool, but this is now done with just one bit. Numeric values can also be added using fewer bits via the `AddBits` methods, or by leveraging the `AddVarULong`/`AddVarLong` methods to dynamically use more or less bits depending on how large the value is.