### PR TITLE
Fix ack message sending redundant sequence ID

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Connection.cs
+++ b/RiptideNetworking/RiptideNetworking/Connection.cs
@@ -308,9 +308,11 @@ namespace Riptide
             if (forSeqId == lastReceivedSeqId)
                 message.AddBool(false);
             else
+            {
                 message.AddBool(true);
                 message.AddUShort(forSeqId);
-            
+            }
+
             Send(message);
         }
 


### PR DESCRIPTION
In `SendAck()` the braces were missing around the `else` block, so it's always appending the sequence id `ushort` to the ack message, which isn't used in `HandleAck()` later if the `bool` was actually `false`.