### PR TITLE
Add connection null check to Client.TimeoutTime setter

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -40,7 +40,10 @@ namespace Riptide
             set
             {
                 defaultTimeout = value;
-                connection.TimeoutTime = defaultTimeout;
+                if (connection != null)
+                {
+                    connection.TimeoutTime = defaultTimeout;
+                }
             }
         }
         /// <summary>Whether or not the client is currently <i>not</i> trying to connect, pending, nor actively connected.</summary>


### PR DESCRIPTION
Connection can be null if you try to set the timeout time before connecting to a server, which would result in a null exception being thrown. 