### PR TITLE
Fix memory leak in UdpServer::connections when rejecting new connections on a full server

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -274,6 +274,7 @@ namespace Riptide
                 message.Release();
             }
 
+            transport.Close(connection);
             connection.ResetTimeout(); // Keep the connection alive for a moment so the same client can't immediately attempt to connect again
             connection.LocalDisconnect();
 


### PR DESCRIPTION
Security Implications:
- could be used to carry out Denial of Service attack
- could happen even in normal conditions without anyone exploiting it

Repro:
1. start new server with small client count (1 or 2)
2. connect to it with a client(s) so that its full
3. attempt to connect to it with any number of additional clients
4. you will see instances left in UdpServer::connections although they should be cleaned up

I tested and confirmed this bug in commit c85b3db157f8225169c0f58331f9c1bc4e218db7 (recent origin/main)
with client and server, from Riptide\Demos\Console.

This PR contains patch for this bug. I have confirmed this patch working using Riptide\Demos\Console project.

