### PR TITLE
Changes access modifier of MessageRelayFilter from "internal" to "public".

### DIFF
--- a/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
+++ b/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
@@ -102,5 +102,8 @@ namespace Riptide
         {
             return (filter[forMessageId / BitsPerInt] & (1 << (forMessageId % BitsPerInt))) != 0;
         }
+
+        /// <inheritdoc cref="ShouldRelay(ushort)"/>
+        public void ShouldRelay(Enum forMessageId) => ShouldRelay((ushort)(object)forMessageId);
     }
 }

--- a/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
+++ b/RiptideNetworking/RiptideNetworking/MessageRelayFilter.cs
@@ -98,7 +98,7 @@ namespace Riptide
         /// <summary>Checks whether or not messages with the given ID should be relayed.</summary>
         /// <param name="forMessageId">The message ID to check.</param>
         /// <returns>Whether or not messages with the given ID should be relayed.</returns>
-        internal bool ShouldRelay(ushort forMessageId)
+        public bool ShouldRelay(ushort forMessageId)
         {
             return (filter[forMessageId / BitsPerInt] & (1 << (forMessageId % BitsPerInt))) != 0;
         }


### PR DESCRIPTION
In short: It's needed to fully support Server's OnMessageReceived(...) method overriding.
Overriding OnMessageReceived(...) method is very useful, as it allows implementing custom handling methods.

RelayFilter has Enable/Disable methods public, but has "ShouldRelay" set to `internal`, which makes RelayFilter useless for developers outside of raw Riptide usage, because while you can set filter values - you can't actually read them.

As you can see from screenshot, RelayFilter.ShouldRelay is also the only method stopping us from allowing overriding:
<img width="1087" height="628" alt="image" src="https://github.com/user-attachments/assets/4cae7ef9-47e3-41fb-8c2c-32afa8789f5a" />
Making this method public will make RelayFilter more useful.