### PR TITLE
Make Message and Client pools thread-safe using ConcurrentDictionary

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Client.cs
+++ b/RiptideNetworking/RiptideNetworking/Client.cs
@@ -96,6 +96,12 @@ namespace Riptide
             transport = newTransport;
         }
 
+        /// <summary>
+        /// Sets whether or not the server should throw an exception when handling messages. If set to <see langword="true"/>, the server will not throw exceptions when handling messages (like normal). Othervise it will throw an exception.
+        /// </summary>
+        /// <param name="preventExceptions">New value for the PREVENT_EXCEPTION property.</param>
+        public void ChangeExceptionPrevention(bool preventExceptions) => Server.SetPreventException(preventExceptions);
+
         /// <summary>Attempts to connect to a server at the given host address.</summary>
         /// <param name="hostAddress">The host address to connect to.</param>
         /// <param name="maxConnectionAttempts">How many connection attempts to make before giving up.</param>
@@ -107,9 +113,11 @@ namespace Riptide
         ///   <para>Setting <paramref name="useMessageHandlers"/> to <see langword="false"/> will disable the automatic detection and execution of methods with the <see cref="MessageHandlerAttribute"/>, which is beneficial if you prefer to handle messages via the <see cref="MessageReceived"/> event.</para>
         /// </remarks>
         /// <returns><see langword="true"/> if a connection attempt will be made. <see langword="false"/> if an issue occurred (such as <paramref name="hostAddress"/> being in an invalid format) and a connection attempt will <i>not</i> be made.</returns>
-        public bool Connect(string hostAddress, int maxConnectionAttempts = 5, byte messageHandlerGroupId = 0, Message message = null, bool useMessageHandlers = true)
+        public bool Connect(string hostAddress, int maxConnectionAttempts = 5, byte messageHandlerGroupId = 0, Message message = null, bool useMessageHandlers = true, bool preventExceptions = true)
         {
             Disconnect();
+
+            Server.SetPreventException(preventExceptions);
 
             SubToTransportEvents();
 

--- a/RiptideNetworking/RiptideNetworking/Connection.cs
+++ b/RiptideNetworking/RiptideNetworking/Connection.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
-// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;

--- a/RiptideNetworking/RiptideNetworking/Connection.cs
+++ b/RiptideNetworking/RiptideNetworking/Connection.cs
@@ -2,11 +2,12 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
+// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Riptide
 {
@@ -104,7 +105,7 @@ namespace Riptide
         /// <summary>The sequencer for reliable messages.</summary>
         private readonly ReliableSequencer reliable;
         /// <summary>The currently pending reliably sent messages whose delivery has not been acknowledged yet. Stored by sequence ID.</summary>
-        private readonly Dictionary<ushort, PendingMessage> pendingMessages;
+        private readonly ConcurrentDictionary<ushort, PendingMessage> pendingMessages;
         /// <summary>The connection's current state.</summary>
         private ConnectionState state;
         /// <summary>The number of consecutive times that the <see cref="MaxAvgSendAttempts"/> threshold was exceeded.</summary>
@@ -136,7 +137,7 @@ namespace Riptide
             MaxSendAttempts = 15;
             MaxNotifyLoss = 0.05f; // 5%
             NotifyLossResilience = 64;
-            pendingMessages = new Dictionary<ushort, PendingMessage>();
+            pendingMessages = new ConcurrentDictionary<ushort, PendingMessage>();
         }
 
         /// <summary>Initializes connection data.</summary>
@@ -184,7 +185,7 @@ namespace Riptide
             {
                 sequenceId = reliable.NextSequenceId;
                 PendingMessage pendingMessage = PendingMessage.Create(sequenceId, message, this);
-                pendingMessages.Add(sequenceId, pendingMessage);
+                pendingMessages.TryAdd(sequenceId, pendingMessage);
                 pendingMessage.TrySend();
                 Metrics.ReliableUniques++;
             }
@@ -249,11 +250,10 @@ namespace Riptide
         /// <param name="sequenceId">The sequence ID that was acknowledged.</param>
         internal void ClearMessage(ushort sequenceId)
         {
-            if (pendingMessages.TryGetValue(sequenceId, out PendingMessage pendingMessage))
+            if (pendingMessages.TryRemove(sequenceId, out PendingMessage pendingMessage))
             {
                 ReliableDelivered?.Invoke(sequenceId);
                 pendingMessage.Clear();
-                pendingMessages.Remove(sequenceId);
                 UpdateSendAttemptsViolations();
             }
         }

--- a/RiptideNetworking/RiptideNetworking/Exceptions.cs
+++ b/RiptideNetworking/RiptideNetworking/Exceptions.cs
@@ -117,6 +117,65 @@ namespace Riptide
         }
     }
 
+    /// <summary>The exception that is thrown when a message does not contain enough bits to retrieve a value of the specified type.</summary>
+    public class ReadingOrderOrCapacityException : Exception
+    {
+        /// <summary>
+        /// The number of unread bits remaining in the message when the exception was thrown. This is not necessarily the number of bits required to retrieve a value of the specified type, as the exception can also be thrown if the reading order is incorrect (e.g. trying to read a byte before reading a preceding bool).
+        /// </summary>
+        public int UnreadBits;
+        /// <summary>
+        /// The number of bits required to retrieve a value of the specified type. This is not necessarily the number of unread bits remaining in the message when the exception was thrown, as the exception can also be thrown if the reading order is incorrect (e.g. trying to read a byte before reading a preceding bool).
+        /// </summary>
+        public int RequiredBits;
+        /// <summary>
+        /// The name of the value that could not be retrieved.
+        /// </summary>
+        public readonly string ValueName;
+
+        /// <summary>Initializes a new <see cref="ReadingOrderOrCapacityException"/> instance.</summary>
+        public ReadingOrderOrCapacityException() { }
+        /// <summary>Initializes a new <see cref="ReadingOrderOrCapacityException"/> instance with a specified error message.</summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public ReadingOrderOrCapacityException(string message) : base(message) { }
+        /// <summary>Initializes a new <see cref="ReadingOrderOrCapacityException"/> instance with a specified error message and a reference to the inner exception that is the cause of this exception.</summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="inner">The exception that is the cause of the current exception. If <paramref name="inner"/> is not a null reference, the current exception is raised in a catch block that handles the inner exception.</param>
+        public ReadingOrderOrCapacityException(string message, Exception inner) : base(message, inner) { }
+        /// <summary>Initializes a new <see cref="ReadingOrderOrCapacityException"/> instance and constructs an error message from the given information.</summary>
+        /// <param name="unreadbits">The number of unread bits remaining in the message when the exception was thrown.</param>
+        /// <param name="declaringType">The name of the type containing the handler method.</param>
+        public ReadingOrderOrCapacityException(int unreadbits, string declaringType) : base(GetErrorMessage(unreadbits, declaringType))
+        {
+            UnreadBits = unreadbits;
+            ValueName = declaringType;
+        }
+
+        /// <summary>Initializes a new <see cref="ReadingOrderOrCapacityException"/> instance and constructs an error message from the given information.</summary>
+        /// <param name="unreadbits">The number of unread bits remaining in the message when the exception was thrown.</param>
+        /// <param name="declaringType">The name of the type containing the handler method.</param>
+        public ReadingOrderOrCapacityException(int unreadbits, int requiredBits, string declaringType) : base(GetErrorMessage(unreadbits, requiredBits, declaringType))
+        {
+            UnreadBits = unreadbits;
+            RequiredBits = requiredBits;
+            ValueName = declaringType;
+        }
+
+
+        /// <summary>Constructs the error message from the given information.</summary>
+        /// <returns>The error message.</returns>
+        private static string GetErrorMessage(int unreadBits, string valueName)
+        {
+            return $"Message only contains {unreadBits} unread {Helper.CorrectForm(unreadBits, "bit")}, which is not enough to retrieve a value of type '{valueName}'!";
+        }
+        /// <summary>Constructs the error message from the given information.</summary>
+        /// <returns>The error message.</returns>
+        private static string GetErrorMessage(int unreadBits, int requiredBits, string valueName)
+        {
+            return $"Message only contains {unreadBits} unread {Helper.CorrectForm(unreadBits, "bit")}, which is not enough to retrieve a value of type '{valueName}' (requires {requiredBits} bits)!";
+        }
+    }
+
     /// <summary>The exception that is thrown when a method with a <see cref="MessageHandlerAttribute"/> does not have an acceptable message handler method signature (either <see cref="Server.MessageHandler"/> or <see cref="Client.MessageHandler"/>).</summary>
     public class InvalidHandlerSignatureException : Exception
     {

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -2,11 +2,12 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
+// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -86,7 +87,7 @@ namespace Riptide
         /// <remarks>Changes will not affect <see cref="Server"/> and <see cref="Client"/> instances which are already running until they are restarted.</remarks>
         public static byte InstancesPerPeer { get; set; } = 4;
         /// <summary>A pool of reusable message instances.</summary>
-        private static readonly List<Message> pool = new List<Message>(InstancesPerPeer * 2);
+        private static readonly ConcurrentDictionary<uint, Message> pool = new ConcurrentDictionary<uint, Message>();
 
         static Message()
         {
@@ -124,8 +125,29 @@ namespace Riptide
         /// <summary>The next bit to be written.</summary>
         private int writeBit;
 
+        /// <summary>Determines which id is this Message.</summary>
+        public uint MessageId { get; private set; } = 0;
+        /// <summary>Determines which is the next value fot give to the next mmessage [LIFO].</summary>
+        private static readonly ConcurrentStack<uint> indexedKeys = new ConcurrentStack<uint>();
+        /// <summary>For give unique ID for each message global thread-safe counter.</summary>
+        private static int globalMessageIdCounter = 0;
+
         /// <summary>Initializes a reusable <see cref="Message"/> instance.</summary>
-        private Message() => data = new ulong[maxArraySize];
+        private Message()
+        {
+            data = new ulong[maxArraySize];
+
+            // UNBREAKABLE THRESHOLD: When the constructor is called, any object not in the pool/in use. Then the atomic loop that continuesly run for tries to find and create UNIQUE ID
+            uint gId;
+            do
+            {
+                // The `interlocked.Increment` int automatically goes negative when it reaches the limit. When it goes negative, the `uint cast` ensures that the transaction volume is at the maximum value the `uint` value can hold, which is 4.2 billion.
+                gId = (uint)System.Threading.Interlocked.Increment(ref globalMessageIdCounter);
+            }
+            while (gId == 0 || pool.ContainsKey(gId));
+
+            MessageId = gId;
+        }
 
         /// <summary>Gets a completely empty message instance with no header.</summary>
         /// <returns>An empty message instance.</returns>
@@ -175,16 +197,15 @@ namespace Riptide
             {
                 // No Servers or Clients are running, empty the list and reset the capacity
                 pool.Clear();
-                pool.Capacity = InstancesPerPeer * 2; // x2 so there's some buffer room for extra Message instances in the event that more are needed
+                indexedKeys.Clear();
             }
             else
             {
                 // Reset the pool capacity and number of Message instances in the pool to what is appropriate for how many Servers & Clients are active
                 int idealInstanceAmount = Peer.ActiveCount * InstancesPerPeer;
-                if (pool.Count > idealInstanceAmount)
+                while (pool.Count > idealInstanceAmount && indexedKeys.TryPop(out uint key))
                 {
-                    pool.RemoveRange(Peer.ActiveCount * InstancesPerPeer, pool.Count - idealInstanceAmount);
-                    pool.Capacity = idealInstanceAmount * 2;
+                    pool.TryRemove(key, out Message _);
                 }
             }
         }
@@ -193,26 +214,19 @@ namespace Riptide
         /// <returns>A message instance ready to be used for sending or handling.</returns>
         private static Message RetrieveFromPool()
         {
-            Message message;
-            if (pool.Count > 0)
-            {
-                message = pool[0];
-                pool.RemoveAt(0);
-            }
-            else
-                message = new Message();
-
-            return message;
+            return indexedKeys.TryPop(out uint key) && pool.TryGetValue(key, out Message message) ? message : new Message();
         }
 
         /// <summary>Returns the message instance to the internal pool so it can be reused.</summary>
         public void Release()
         {
-            if (pool.Count < pool.Capacity)
+            int idealCap = Peer.ActiveCount < 1 ? InstancesPerPeer * 2 : Peer.ActiveCount * InstancesPerPeer;
+            if (pool.Count < idealCap)
             {
-                // Pool exists and there's room
-                if (!pool.Contains(this))
-                    pool.Add(this); // Only add it if it's not already in the list, otherwise this method being called twice in a row for whatever reason could cause *serious* issues
+                if (pool.ContainsKey(MessageId) == false && pool.TryAdd(MessageId, this)) // Only add it if it's not already in the list, otherwise this method being called twice in a row for whatever reason could cause *serious* issues
+                {
+                    indexedKeys.Push(MessageId);
+                }
             }
         }
         #endregion

--- a/RiptideNetworking/RiptideNetworking/Message.cs
+++ b/RiptideNetworking/RiptideNetworking/Message.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
-// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
@@ -622,8 +621,12 @@ namespace Riptide
         {
             if (UnreadBits < BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ByteName, $"{default(byte)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ByteName, $"{default(byte)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, ByteName);
             }
 
             byte value = Converter.ByteFromBits(data, readBit);
@@ -637,8 +640,12 @@ namespace Riptide
         {
             if (UnreadBits < BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(SByteName, $"{default(sbyte)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(SByteName, $"{default(sbyte)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnwrittenBits, SByteName);
             }
 
             sbyte value = Converter.SByteFromBits(data, readBit);
@@ -811,8 +818,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ByteName));
-                amount = UnreadBits / BitsPerByte;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ByteName));
+                    amount = UnreadBits / BitsPerByte;
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * BitsPerByte, ByteName);
             }
 
             if (readBit % BitsPerByte == 0)
@@ -838,8 +849,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, SByteName));
-                amount = UnreadBits / BitsPerByte;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, SByteName));
+                    amount = UnreadBits / BitsPerByte;
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * BitsPerByte, SByteName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -869,8 +884,12 @@ namespace Riptide
         {
             if (UnreadBits < 1)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(BoolName, $"{default(bool)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(BoolName, $"{default(bool)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, BoolName);
             }
 
             return Converter.BoolFromBit(data, readBit++);
@@ -930,8 +949,12 @@ namespace Riptide
         {
             if (UnreadBits < amount)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, BoolName));
-                amount = UnreadBits;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, BoolName));
+                    amount = UnreadBits;
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount, BoolName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -972,8 +995,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(short) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ShortName, $"{default(short)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ShortName, $"{default(short)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, ShortName);
             }
 
             short value = Converter.ShortFromBits(data, readBit);
@@ -987,8 +1014,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(ushort) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UShortName, $"{default(ushort)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UShortName, $"{default(ushort)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, UShortName);
             }
 
             ushort value = Converter.UShortFromBits(data, readBit);
@@ -1102,8 +1133,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(short) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ShortName));
-                amount = UnreadBits / (sizeof(short) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ShortName));
+                    amount = UnreadBits / (sizeof(short) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(short) * BitsPerByte, ShortName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1121,8 +1156,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(ushort) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UShortName));
-                amount = UnreadBits / (sizeof(ushort) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UShortName));
+                    amount = UnreadBits / (sizeof(ushort) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(ushort) * BitsPerByte, UShortName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1166,8 +1205,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(int) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(IntName, $"{default(int)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(IntName, $"{default(int)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, IntName);
             }
 
             int value = Converter.IntFromBits(data, readBit);
@@ -1181,8 +1224,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(uint) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UIntName, $"{default(uint)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(UIntName, $"{default(uint)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, UIntName);
             }
 
             uint value = Converter.UIntFromBits(data, readBit);
@@ -1296,8 +1343,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(int) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, IntName));
-                amount = UnreadBits / (sizeof(int) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, IntName));
+                    amount = UnreadBits / (sizeof(int) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(int) * BitsPerByte, IntName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1315,8 +1366,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(uint) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UIntName));
-                amount = UnreadBits / (sizeof(uint) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, UIntName));
+                    amount = UnreadBits / (sizeof(uint) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(uint) * BitsPerByte, UIntName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1360,8 +1415,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(long) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(LongName, $"{default(long)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(LongName, $"{default(long)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, LongName);
             }
 
             long value = Converter.LongFromBits(data, readBit);
@@ -1375,8 +1434,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(ulong) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ULongName, $"{default(ulong)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(ULongName, $"{default(ulong)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, ULongName);
             }
 
             ulong value = Converter.ULongFromBits(data, readBit);
@@ -1490,8 +1553,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(long) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, LongName));
-                amount = UnreadBits / (sizeof(long) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, LongName));
+                    amount = UnreadBits / (sizeof(long) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(long) * BitsPerByte, LongName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1509,8 +1576,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(ulong) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ULongName));
-                amount = UnreadBits / (sizeof(ulong) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, ULongName));
+                    amount = UnreadBits / (sizeof(ulong) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(ulong) * BitsPerByte, ULongName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1541,8 +1612,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(float) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(FloatName, $"{default(float)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(FloatName, $"{default(float)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, FloatName);
             }
 
             float value = Converter.FloatFromBits(data, readBit);
@@ -1607,8 +1682,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(float) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, FloatName));
-                amount = UnreadBits / (sizeof(float) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, FloatName));
+                    amount = UnreadBits / (sizeof(float) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(float) * BitsPerByte, FloatName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1639,8 +1718,12 @@ namespace Riptide
         {
             if (UnreadBits < sizeof(double) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(DoubleName, $"{default(double)}"));
-                return default;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(DoubleName, $"{default(double)}"));
+                    return default;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, DoubleName);
             }
 
             double value = Converter.DoubleFromBits(data, readBit);
@@ -1705,8 +1788,12 @@ namespace Riptide
         {
             if (UnreadBits < amount * sizeof(double) * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, DoubleName));
-                amount = UnreadBits / (sizeof(double) * BitsPerByte);
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(amount, DoubleName));
+                    amount = UnreadBits / (sizeof(double) * BitsPerByte);
+                }
+                else throw new ReadingOrderOrCapacityException(UnreadBits, amount * sizeof(double) * BitsPerByte, DoubleName);
             }
 
             for (int i = 0; i < amount; i++)
@@ -1734,8 +1821,12 @@ namespace Riptide
             int length = (int)GetVarULong(); // Get the length of the string (in bytes, NOT characters)
             if (UnreadBits < length * BitsPerByte)
             {
-                RiptideLogger.Log(LogType.Error, NotEnoughBitsError(StringName, "shortened string"));
-                length = UnreadBits / BitsPerByte;
+                if (Server.PREVENT_EXCEPTION)
+                {
+                    RiptideLogger.Log(LogType.Error, NotEnoughBitsError(StringName, "shortened string"));
+                    length = UnreadBits / BitsPerByte;
+                }
+                throw new ReadingOrderOrCapacityException(UnreadBits, length * BitsPerByte, StringName);
             }
 
             string value = Encoding.UTF8.GetString(GetBytes(length), 0, length);

--- a/RiptideNetworking/RiptideNetworking/PendingMessage.cs
+++ b/RiptideNetworking/RiptideNetworking/PendingMessage.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
-// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;

--- a/RiptideNetworking/RiptideNetworking/PendingMessage.cs
+++ b/RiptideNetworking/RiptideNetworking/PendingMessage.cs
@@ -2,10 +2,12 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
+// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Riptide
@@ -20,7 +22,13 @@ namespace Riptide
         private const float RetryTimeMultiplier = 1.2f;
 
         /// <summary>A pool of reusable <see cref="PendingMessage"/> instances.</summary>
-        private static readonly List<PendingMessage> pool = new List<PendingMessage>();
+        private static readonly ConcurrentDictionary<uint, PendingMessage> pool = new ConcurrentDictionary<uint, PendingMessage>();
+        /// <summary>For give uniue ID to the each pending Message global thread-safe counter.</summary>
+        private static int globalPendingMessageIdCounter = 0;
+        /// <summary>Determines which id is this PendingMessage.</summary>
+        internal uint PendingMessageId { get; private set; } = 0;
+        /// <summary>Determines which is the next value for giving to the next pending message [LIFO].</summary>
+        private static readonly ConcurrentStack<uint> indexedKeys = new ConcurrentStack<uint>();
 
         /// <summary>The <see cref="Connection"/> to use to send (and resend) the pending message.</summary>
         private Connection connection;
@@ -37,6 +45,16 @@ namespace Riptide
         internal PendingMessage()
         {
             data = new byte[Message.MaxSize];
+
+            // UNBREAKABLE THRESHOLD: When the constructor is called, any object not in the pool/in use. Then the atomic loop that continuesly run for tries to find and create UNIQUE ID
+            uint gId;
+            do
+            {
+                // The `interlocked.Increment` int automatically goes negative when it reaches the limit. When it goes negative, the `uint cast` ensures that the transaction volume is at the maximum value the `uint` value can hold, which is 4.2 billion.
+                gId = (uint)System.Threading.Interlocked.Increment(ref globalPendingMessageIdCounter);
+            }
+            while (gId == 0 || pool.ContainsKey(gId));
+            PendingMessageId = gId;
         }
 
         #region Pooling
@@ -63,29 +81,32 @@ namespace Riptide
         /// <returns>A <see cref="PendingMessage"/> instance.</returns>
         private static PendingMessage RetrieveFromPool()
         {
-            PendingMessage message;
-            if (pool.Count > 0)
+            if (indexedKeys.TryPop(out uint key))
             {
-                message = pool[0];
-                pool.RemoveAt(0);
+                if (pool.TryRemove(key, out PendingMessage message))
+                {
+                    return message;
+                }
             }
-            else
-                message = new PendingMessage();
 
-            return message;
+            // constructor will give an unique id as i made it in the Message.cs
+            return new PendingMessage();
         }
 
         /// <summary>Empties the pool. Does not affect <see cref="PendingMessage"/> instances which are actively pending and therefore not in the pool.</summary>
         public static void ClearPool()
         {
             pool.Clear();
+            indexedKeys.Clear();
         }
 
         /// <summary>Returns the <see cref="PendingMessage"/> instance to the pool so it can be reused.</summary>
         private void Release()
         {
-            if (!pool.Contains(this))
-                pool.Add(this); // Only add it if it's not already in the list, otherwise this method being called twice in a row for whatever reason could cause *serious* issues
+            if (pool.ContainsKey(PendingMessageId) == false && pool.TryAdd(PendingMessageId, this)) // Only add it if it's not already in the list, otherwise this method being called twice in a row for whatever reason could cause *serious* issues
+            {
+                indexedKeys.Push(PendingMessageId);
+            } 
 
             // TODO: consider doing something to decrease pool capacity if there are far more
             //       available instance than are needed, which could occur if a large burst of

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
-// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
@@ -74,6 +73,14 @@ namespace Riptide
         /// <summary>All currently unused client IDs.</summary>
         private ConcurrentQueue<ushort> availableClientIds;
 
+        /// <summary>This bool using for preventing exceptions. If set to true, the server will not throw exceptions when handling messages (like normal). Othervise it will throw an exception.</summary>
+        public static bool PREVENT_EXCEPTION { get; private set; } = true;
+        /// <summary>
+        /// Sets whether or not the server should throw an exception when handling messages. If set to <see langword="true"/>, the server will not throw exceptions when handling messages (like normal). Othervise it will throw an exception.
+        /// </summary>
+        /// <param name="value">New value for the PREVENT_EXCEPTION property.</param>
+        public static void SetPreventException(bool value) => PREVENT_EXCEPTION = value;
+
         /// <summary>Handles initial setup.</summary>
         /// <param name="transport">The transport to use for sending and receiving data.</param>
         /// <param name="logName">The name to use when logging messages via <see cref="RiptideLogger"/>.</param>
@@ -90,22 +97,31 @@ namespace Riptide
 
         /// <summary>Stops the server if it's running and swaps out the transport it's using.</summary>
         /// <param name="newTransport">The new underlying transport server to use for sending and receiving data.</param>
-        /// <remarks>This method does not automatically restart the server. To continue accepting connections, <see cref="Start(ushort, ushort, byte, bool)"/> must be called again.</remarks>
+        /// <remarks>This method does not automatically restart the server. To continue accepting connections, <see cref="Start(ushort, ushort, byte, bool, bool)"/> must be called again.</remarks>
         public void ChangeTransport(IServer newTransport)
         {
             Stop();
             transport = newTransport;
         }
 
+        /// <summary>
+        /// Sets whether or not the server should throw an exception when handling messages. If set to <see langword="true"/>, the server will not throw exceptions when handling messages (like normal). Othervise it will throw an exception.
+        /// </summary>
+        /// <param name="preventExceptions">New value for the PREVENT_EXCEPTION property.</param>
+        public void ChangeExceptionPrevention(bool preventExceptions) => SetPreventException(preventExceptions);
+
         /// <summary>Starts the server.</summary>
         /// <param name="port">The local port on which to start the server.</param>
         /// <param name="maxClientCount">The maximum number of concurrent connections to allow.</param>
         /// <param name="messageHandlerGroupId">The ID of the group of message handler methods to use when building <see cref="messageHandlers"/>.</param>
         /// <param name="useMessageHandlers">Whether or not the server should use the built-in message handler system.</param>
+        /// <param name="preventExceptions">Whether or not the server should prevent exceptions when handling messages.</param>
         /// <remarks>Setting <paramref name="useMessageHandlers"/> to <see langword="false"/> will disable the automatic detection and execution of methods with the <see cref="MessageHandlerAttribute"/>, which is beneficial if you prefer to handle messages via the <see cref="MessageReceived"/> event.</remarks>
-        public void Start(ushort port, ushort maxClientCount, byte messageHandlerGroupId = 0, bool useMessageHandlers = true)
+        public void Start(ushort port, ushort maxClientCount, byte messageHandlerGroupId = 0, bool useMessageHandlers = true, bool preventExceptions = true)
         {
             Stop();
+
+            SetPreventException(preventExceptions);
 
             IncreaseActiveCount();
             this.useMessageHandlers = useMessageHandlers;

--- a/RiptideNetworking/RiptideNetworking/Server.cs
+++ b/RiptideNetworking/RiptideNetworking/Server.cs
@@ -2,11 +2,13 @@
 // Copyright (c) Tom Weiland
 // For additional information please see the included LICENSE.md file or view it on GitHub:
 // https://github.com/RiptideNetworking/Riptide/blob/main/LICENSE.md
+// Modified from Erol Bircan
 
 using Riptide.Transports;
 using Riptide.Utils;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 
@@ -34,7 +36,7 @@ namespace Riptide
             set
             {
                 defaultTimeout = value;
-                foreach (Connection connection in clients.Values)
+                foreach (Connection connection in Clients)
                     connection.TimeoutTime = defaultTimeout;
             }
         }
@@ -62,7 +64,7 @@ namespace Riptide
         /// <summary>Currently pending connections which are waiting to be accepted or rejected.</summary>
         private readonly List<Connection> pendingConnections;
         /// <summary>Currently connected clients.</summary>
-        private Dictionary<ushort, Connection> clients;
+        private ConcurrentDictionary<ushort, Connection> clients;
         /// <summary>Clients that have timed out and need to be removed from <see cref="clients"/>.</summary>
         private readonly List<Connection> timedOutClients;
         /// <summary>Methods used to handle messages, accessible by their corresponding message IDs.</summary>
@@ -70,7 +72,7 @@ namespace Riptide
         /// <summary>The underlying transport's server that is used for sending and receiving data.</summary>
         private IServer transport;
         /// <summary>All currently unused client IDs.</summary>
-        private Queue<ushort> availableClientIds;
+        private ConcurrentQueue<ushort> availableClientIds;
 
         /// <summary>Handles initial setup.</summary>
         /// <param name="transport">The transport to use for sending and receiving data.</param>
@@ -79,7 +81,7 @@ namespace Riptide
         {
             this.transport = transport;
             pendingConnections = new List<Connection>();
-            clients = new Dictionary<ushort, Connection>();
+            clients = new ConcurrentDictionary<ushort, Connection>();
             timedOutClients = new List<Connection>();
         }
         /// <summary>Handles initial setup using the built-in UDP transport.</summary>
@@ -111,7 +113,7 @@ namespace Riptide
                 CreateMessageHandlersDictionary(messageHandlerGroupId);
 
             MaxClientCount = maxClientCount;
-            clients = new Dictionary<ushort, Connection>(maxClientCount);
+            clients = new ConcurrentDictionary<ushort, Connection>();
             InitializeClientIds();
 
             SubToTransportEvents();
@@ -192,7 +194,7 @@ namespace Riptide
                 AcceptConnection(connection);
             else if (ClientCount < MaxClientCount)
             {
-                if (!clients.ContainsValue(connection) && !pendingConnections.Contains(connection))
+                if (!clients.ContainsKey(connection.Id) && !pendingConnections.Contains(connection))
                 {
                     pendingConnections.Add(connection);
                     Send(Message.Create(MessageHeader.Connect), connection); // Inform the client we've received the connection attempt
@@ -235,17 +237,19 @@ namespace Riptide
         {
             if (ClientCount < MaxClientCount)
             {
-                if (!clients.ContainsValue(connection))
+                ushort clientId = GetAvailableClientId();
+                if (clients.TryAdd(clientId, connection))
                 {
-                    ushort clientId = GetAvailableClientId();
                     connection.Id = clientId;
-                    clients.Add(clientId, connection);
                     connection.ResetTimeout();
                     connection.SendWelcome();
                     return;
                 }
                 else
+                {
                     Reject(connection, RejectReason.AlreadyConnected);
+                    availableClientIds.Enqueue(clientId);
+                }
             }
             else
                 Reject(connection, RejectReason.ServerFull);
@@ -445,8 +449,7 @@ namespace Riptide
 
             transport.Close(client);
 
-            if (clients.Remove(client.Id))
-                availableClientIds.Enqueue(client.Id);
+            if (clients.TryRemove(client.Id, out Connection _)) availableClientIds.Enqueue(client.Id);
 
             if (client.IsConnected)
                 OnClientDisconnected(client, reason); // Only run if the client was ever actually connected
@@ -488,7 +491,7 @@ namespace Riptide
             if (MaxClientCount > ushort.MaxValue - 1)
                 throw new Exception($"A server's max client count may not exceed {ushort.MaxValue - 1}!");
 
-            availableClientIds = new Queue<ushort>(MaxClientCount);
+            availableClientIds = new ConcurrentQueue<ushort>();
             for (ushort i = 1; i <= MaxClientCount; i++)
                 availableClientIds.Enqueue(i);
         }
@@ -497,8 +500,8 @@ namespace Riptide
         /// <returns>The client ID. 0 if none were available.</returns>
         private ushort GetAvailableClientId()
         {
-            if (availableClientIds.Count > 0)
-                return availableClientIds.Dequeue();
+            if (availableClientIds.TryDequeue(out ushort id))
+                return id;
             
             RiptideLogger.Log(LogType.Error, LogName, "No available client IDs, assigned 0!");
             return 0;


### PR DESCRIPTION
### Summary of Changes

I have developed a highly efficient, multi-threaded, and thread-safe networking architectural pattern for RiptideNetworking, specifically designed for high-concurrency projects like MMORPGs. 

#### The Problem: Thread Contention & Race Conditions
When offloading network I/O operations to a dedicated background thread (e.g., executing `Server.Update()` asynchronously to keep the main game loop responsive), serious race conditions occur. The primary culprit is Riptide’s internal message pool (`Message.Create()`, `Message.Release()`). Accessing the message pool concurrently from both the Main Thread (Game Logic) and the Background Thread (Network Loop) corrupts internal byte arrays, leading to network desynchronization, corrupted data, and server crashes.

#### The Solution: The Command Pattern & Asynchronous Action Queue
To bridge the gap between the Main Thread and the Network Thread safely without expensive resource locking, I implemented a custom **Command Pattern execution pipeline** combined with a `ConcurrentQueue`.

1. **Incoming Request Queuing:** Network message handlers running on the background thread no longer execute game logic or manipulate the message pool directly. Instead, they deserialize raw data into lightweight, immutable `INetworkCommand` structures and enqueue them into a thread-safe `ConcurrentQueue`.

```
public static readonly ConcurrentQueue<INetworkCommand> ACTION_QUEUE = new();
public interface INetworkCommand
{
    ushort ClientId { get; }
    void Execute();
}

private class PPromo : INetworkCommand
{
    public ushort ClientId { get; set; }
    public string promocode { get; set; }

    public void Execute()
    {
        if (CheckIsInList(ClientId, out Player player))
        {
            bool success = TryClaimPromoLocal(player, promocode);
            Message message = Message.Create(MessageSendMode.Reliable, ServerToClientId.PromoResult);
            message.AddBool(success);
            NetworkManager.Singleton.Server.Send(message, ClientId);
        }
    }
}
[MessageHandler((ushort)ClientToServerId.PromoRequest)]
private static void PROCMO_ACTIVATE(ushort fromClientId, Message message)
{
    NetworkManager.ACTION_QUEUE.Enqueue(new PPromo() { ClientId = fromClientId, promocode = message.GetString() });
}
```

2. Main Thread Thread-Safe Execution & Frame Budgeting: The Main Thread dequeues and processes these commands sequentially during its standard `Update()` loop. To ensure server stability and prevent CPU spikes caused by a massive surge of packets, I integrated a Frame Budget Monitor using a `Stopwatch`. If processing takes longer than the allocated frame time budget `(MaxFrameMs)`, the execution breaks, deferred actions are carried over to the next frame, and a warning is logged.

```
private readonly System.Diagnostics.Stopwatch SW = new();
private void Update()
{
        SW.Restart();
        while (ACTION_QUEUE.TryDequeue(out INetworkCommand CR))
        {
            CR.Execute();

            ACTION_REQUEST_COUNTER.AddOrUpdate(CR.ClientId, 0, (o, k) => (byte)(k - 1));

            // Frame Budgeting Control (e.g., ~33.3ms for a 30-Tick Server)
            if (SW.ElapsedMilliseconds > MaxFrameMs)
            {
                Debug.LogWarning($"{{{TICK_FORDEBUG}}} - [Performans] Bu frame'de {SW.ElapsedMilliseconds}ms harcandı! (Dikkat: {CR.GetType().Name}). Kalan istekleri bir sonrakine aktarılıyor.");
                break;
            }
        }
}
```

3. Isolated Background Network Loop: With the main loop freed from networking I/O overhead, `Server.Update()` runs continuously on a high-priority background worker thread, throttled naturally to prevent CPU core exhaustion.

```
            SERVER_THREAD = new Thread(() => ServerThreadLoop())
            {
                Name = "MokSha-Rin Riptide Server",
                IsBackground = true
            };
            SERVER_THREAD.Start();
    private void ServerThreadLoop()
    {
        try
        {
            while (!GLOBAL_SOURCE.Token.IsCancellationRequested && !QUIT_FLAG)
            {
                // read Riptide packages and fill the actionqueue
                if (Server != null && Server.IsRunning)
                {
                    Server.Update();
                }

                //preventing cpu lock making the thread sleep for a tiny duration and also check for requesting server is going to shutdown
                Thread.Sleep(16);
                GLOBAL_SOURCE.Token.ThrowIfCancellationRequested();
            }
        }
        catch (Exception ex)
        {
            Debug.LogError($"{{{TICK_FORDEBUG}}} - [SERVER - CORE] Server error: {ex.Message}");
        }
        finally
        {
            Debug.Log($"{{{TICK_FORDEBUG}}} - [SERVER - CORE] Server has shutdown (Loop end).");
        }
    }
```

4. Why we need this ?

```
public void Execute()
    {
        if (CheckIsInList(ClientId, out Player player))
        {
            bool success = TryClaimPromoLocal(player, promocode);
            Message message = Message.Create(MessageSendMode.Reliable, ServerToClientId.PromoResult);
            message.AddBool(success);
            NetworkManager.Singleton.Server.Send(message, ClientId);
        }
    }
```


`Message message = Message.Create(MessageSendMode.Reliable, ServerToClientId.PromoResult);`
**Why This is Vital for the Community**
By enforcing this design, Riptide’s pooling mechanism (Message.Create) is only ever touched from a single thread sequence during actual processing, completely eliminating Riptide-pool-related Multi-Thread crashes. I wanted to share this architectural solution with the Riptide community to help anyone struggling to transition their dedicated servers to an asynchronous, high-performance, and crash-proof multi-threaded environment. Hope it helps!